### PR TITLE
Fix: Correct X-Rate-Limit-* header meaning.

### DIFF
--- a/Werkgroep API strategie/3-API strategie.md
+++ b/Werkgroep API strategie/3-API strategie.md
@@ -918,8 +918,8 @@ HTTP headers worden gebruikt om de bevragingslimit naar de gebruiker te communic
 |HTTP header|Toelichting|
 |-|-|
 |`X-Rate-Limit-Limit`|Geeft aan hoeveel verzoeken een applicatie mag doen per tijdsperiode. Voor het DSO is dit 60 seconden|
-|`X-Rate-Limit-Remaining`|Geeft aan hoeveel seconden over zijn in de huidige tijdsperiode|
-|`X-Rate-Limit-Reset`|Geeft aan hoeveel verzoeken nog gedaan kunnen worden in de huidige tijdsperiode|
+|`X-Rate-Limit-Remaining`|Geeft aan hoeveel verzoeken nog gedaan kunnen worden in de huidige tijdsperiode|
+|`X-Rate-Limit-Reset`|Geeft aan hoeveel seconden over zijn in de huidige tijdsperiode|
 
 > **Beperken van het aantal verzoeken per tijdsperiode wordt centraal opgelost door het Stelselknooppunt**
 >


### PR DESCRIPTION
## This PR

Fixes the X-Rate-Limit-* definitions (two lines were swapped).

## Note

In Italy:

- we're currently using X-RateLimit-* and we expect to provide some plugins for actual api-gateways (eg there's a patch for kong https://github.com/Kong/kong/pull/3451) while tyk already uses X-RateLimit-*
- we will *enforce* X-RateLimit-* headers for all interoperable services, especially for payments and taxes sector.

If you want to discuss further just let me know!