### PR TITLE
Add API rule for CRS of geometry in request body

### DIFF
--- a/API-strategie-extensies/ext-geospatial.md
+++ b/API-strategie-extensies/ext-geospatial.md
@@ -122,7 +122,7 @@ Since most client-side mapping libraries use WGS84, the W3C/OGC working group *S
   <p>General usage of the European ETRS89 coordinate reference system (CRS) is preferable, but is not necessarily the default CRS. Hence, the CRS has to be explicitly included in each request.</p>
 </div>
 
-The CRS can be specified for request and response individually using parameters and headers.
+The CRS can be specified for request and response individually using parameters or headers.
 
 The guiding principles for CRS support:
 
@@ -136,7 +136,7 @@ The guiding principles for CRS support:
 - Exchange format (notation) RD and Web Mercator X Y in meters: `195427.5200 311611.8400`
 
 <div class="rule" id="api-41">
-  <p class="rulelab"><strong>API-41</strong>: Pass the coordinate reference system (CRS) of a request parameter as a parameter</p>
+  <p class="rulelab"><strong>API-41</strong>: Pass the coordinate reference system (CRS) of the geometry in a request parameter as a parameter</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_parameter_bbox_crs">OGC API Features part 2 <code>bbox_crs</code> parameter</a> in conformance to the standard.
   </p>
   <p>Additionally, if other types of geospatial filters are supported in the API besides <code>bbox</code>: </p>

--- a/API-strategie-extensies/ext-geospatial.md
+++ b/API-strategie-extensies/ext-geospatial.md
@@ -42,8 +42,8 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
 
 A spatial filter can be complex and large. It is best practice to supply complex queries in the body, not in the request URI. Since `GET` may not have a payload (although supported by some clients) use a `POST` request to a separate endpoint. For example, a GEO query to all *panden* where the geometry in the field `_geo` (there may be multiple geometry fields) contains a GeoJSON object (in this case a `Point`, so one coordinate pair):
 
-<div class="rule" id="api-36">
-  <p class="rulelab"><strong>API-36</strong>: Provide a <code>POST</code> endpoint for geo queries</p>
+<div class="rule" id="api-37">
+  <p class="rulelab"><strong>API-37</strong>: Provide a <code>POST</code> endpoint for geo queries</p>
   <p>Spatial queries are sent in a <code>POST</code> to a dedicated endpoint.</p>
   <pre>
   // POST /api/v1/panden/_zoek with request body:
@@ -61,8 +61,8 @@ A spatial filter can be complex and large. It is best practice to supply complex
 
 <aside class="issue" data-number="281">Er is discussie over het gebruik van POST. <code>bbox</code> filter is toegevoegd. Wellicht POST endpoint laten vervallen.</aside>
 
-<div class="rule" id="api-37">
-  <p class="rulelab"><strong>API-37</strong>: Support mixed queries at <code>POST</code> endpoints</p>
+<div class="rule" id="api-38">
+  <p class="rulelab"><strong>API-38</strong>: Support mixed queries at <code>POST</code> endpoints</p>
   <p>The <code>POST</code> endpoint is preferably set up as a generic query endpoint to support combined queries:</p>
   <pre>
   // POST /api/v1/panden/_zoek with request body:
@@ -78,8 +78,8 @@ A spatial filter can be complex and large. It is best practice to supply complex
   </pre>
 </div>
 
-<div class="rule" id="api-38">
-  <p class="rulelab"><strong>API-38</strong>: Place results of a global spatial query in the relevant geometric context</p>
+<div class="rule" id="api-39">
+  <p class="rulelab"><strong>API-39</strong>: Place results of a global spatial query in the relevant geometric context</p>
   <p>In case of a global query <code>/api/v1/_zoek</code>, results should be placed in the relevant geometric context, because results from different collections are retrieved. Express the name of the collection to which the results belongs in the singular form using the property <code>type</code>. For example:</p>
   <pre>
   // POST /api/v1/_zoek:
@@ -117,12 +117,12 @@ The default CRS (Coordinate Reference System) for GeoJSON is WGS84. This is the 
 
 Since most client-side mapping libraries use WGS84, the W3C/OGC working group *Spatial Data on the Web* recommends to use this as the default coordinate reference system. Thus, spatial data can be mapped without any complex transformations. The API strategy caters for this supporting not only ETRS89 and RD/Amersfoort, but also WGS84 and Web Mercator (EPSG:3857).
 
-<div class="rule" id="api-39">
-  <p class="rulelab"><strong>API-39</strong>: Use ETRS89 as the preferred coordinate reference system (CRS)</p>
+<div class="rule" id="api-40">
+  <p class="rulelab"><strong>API-40</strong>: Use ETRS89 as the preferred coordinate reference system (CRS)</p>
   <p>General usage of the European ETRS89 coordinate reference system (CRS) is preferable, but is not necessarily the default CRS. Hence, the CRS has to be explicitly included in each request.</p>
 </div>
 
-The CRS can be specified for request and response individually using parameters: RD/Amersfoort, ETRS89, WGS84, and Web Mercator.
+The CRS can be specified for request and response individually using parameters and headers.
 
 The guiding principles for CRS support:
 
@@ -135,8 +135,8 @@ The guiding principles for CRS support:
 - Exchange format (notation) ETRS89 and WGS84 X Y in decimal degrees: DD.ddddddddd (for example: `5.962376256, 52.255023450`)
 - Exchange format (notation) RD and Web Mercator X Y in meters: `195427.5200 311611.8400`
 
-<div class="rule" id="api-40">
-  <p class="rulelab"><strong>API-40</strong>: Pass the coordinate reference system (CRS) of the request as a parameter</p>
+<div class="rule" id="api-41">
+  <p class="rulelab"><strong>API-41</strong>: Pass the coordinate reference system (CRS) of a request parameter as a parameter</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_parameter_bbox_crs">OGC API Features part 2 <code>bbox_crs</code> parameter</a> in conformance to the standard.
   </p>
   <p>Additionally, if other types of geospatial filters are supported in the API besides <code>bbox</code>: </p>
@@ -144,14 +144,20 @@ The guiding principles for CRS support:
   </p>
 </div>
 
-<div class="rule" id="api-41">
-  <p class="rulelab"><strong>API-41</strong>: Pass the desired CRS of the response as a parameter</p>
+<div class="rule" id="api-42">
+  <p class="rulelab"><strong>API-42</strong>: Pass the coordinate reference system (CRS) of geometry in the request body as a header</p>
+  <p>Support the <a href="http://docs.ogc.org/DRAFTS/20-002.html#feature-crs">OGC API Features part 4 <code>Content-Crs</code> header</a> in conformance to the standard.</p>
+  <p>Alternatively, if the feature representation supports expressing CRS information for each feature / geometry, the information can also be included in the feature representation.<p>
+</div>
+
+<div class="rule" id="api-43">
+  <p class="rulelab"><strong>API-43</strong>: Pass the desired coordinate reference system (CRS) of geometry in the response as a parameter</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_parameter_crs">OGC API Features part 2 <code>crs</code> parameter</a> in conformance to the standard.
   </p>
 </div>
 
-<div class="rule" id="api-42">
-  <p class="rulelab"><strong>API-42</strong>: Assert the CRS used in the response using a header</p>
+<div class="rule" id="api-44">
+  <p class="rulelab"><strong>API-44</strong>: Assert the coordinate reference system (CRS) used in the response using a header</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_coordinate_reference_system_information_independent_of_the_feature_encoding">OGC API Features part 2 <code>Content-Crs</code> header</a> in conformance to the standard.
   </p>
 </div>
@@ -161,9 +167,10 @@ The API should be able to handle the following scenarios based on the rules stat
 | Scenario                                        | Explanation |
 | ----------------------------------------------- | ----------- |
 | No geometry in request, no geometry in response | No CRS negotiation necessary |
-| No geometry in request, geometry in response    | The client can request a specific CRS for the geometries in the response using the `crs` parameter. The server indicates the geometry CRS in the response using the `content-crs` header. | 
-| Geometry in request, no geometry in response    | The client indicates the CRS of the request geometry using the `bbox-crs` parameter if a bounding box is used to filter geospatially, or the `filter-crs` parameter if another way of geospatial filtering is used.|
-| Geometry in request, geometry in response       | The client indicates the CRS of the request geometry using `bbox-crs` or `filter-crs` as in the previous scenario, and requests a specific CRS for the geometries in the response using the `crs` parameter. The server indicates the geometry CRS in response using the `content-crs` header.|
+| No geometry in request, geometry in response    | The client can request a specific CRS for the geometries in the response using the `crs` parameter. The server indicates the geometry CRS in the response using the `Content-Crs` header. |
+| Geometry in request body, no geometry in response | The client indicates the CRS of the geometry in the request body using the `Content-Crs` header. |
+| Geometry filter in request, no geometry in response    | The client indicates the CRS of the geometry filter in the request using the `bbox-crs` parameter if a bounding box is used to filter geospatially, or the `filter-crs` parameter if another way of geospatial filtering is used.|
+| Geometry filter in request, geometry in response       | The client indicates the CRS of the geometry filter in the request using `bbox-crs` or `filter-crs` as in the previous scenario, and requests a specific CRS for the geometries in the response using the `crs` parameter. The server indicates the geometry CRS in response using the `Content-Crs` header.|
 
 Use the following URIs to specify the CRS:
 
@@ -182,8 +189,8 @@ For backwards compatibility, an older method of specifying CRS in the headers of
 
 If a client specifies CRS using a parameter AND in the header, the parameter takes precedence and the CRS in the header is ignored.
 
-<div class="note" id="api-40-dep">
-  <p><strong>API-40-dep</strong>: Pass the coordinate reference system (CRS) of the request and the response in the headers</p>
+<div class="note" id="api-41-dep">
+  <p><strong>API-41-dep</strong>: Pass the coordinate reference system (CRS) of the request and the response in the headers</p>
   <p><strong>Deprecated</strong></p>
   <p>The coordinate reference system (CRS) for both the request and the response are passed as part of the request headers and response headers. In case this header is missing, send the HTTP status code <code>412 Precondition Failed</code>.</p>
 
@@ -216,7 +223,7 @@ The preferred CRS for the geometry in the response (response body) is specified 
 
 Certified software is available to the national government to transform between coordinate reference systems.
 
-<div class="rule" id="api-41">
-  <p class="rulelab"><strong>API-41</strong>: Use content negotiation to serve different CRSs</p>
+<div class="rule" id="api-45">
+  <p class="rulelab"><strong>API-45</strong>: Use content negotiation to serve different CRSs</p>
   <p>The CRS for the geometry in the response body is defined using the <code>Accept-Crs</code> header. In case the API does not support the requested CRS, send the HTTP status code <code>406 Not Acceptable</code>.</p>
 </div>


### PR DESCRIPTION
API rule-42 is toegevoegd om uit te leggen dat de CRS van geometrie in de request body opgegeven wordt via de HTTP header `Content-Crs`. Dit is ook als scenario opgenomen in de tabel.

De tekst van API rule-41 is aangepast om duidelijker te maken dat het om de CRS van URI parameters gaat.

De API rules zijn tevens hernummerd vanwege dubbelingen.