### PR TITLE
Aanpassingen t.b.v. issue 475

### DIFF
--- a/API-strategie-modulen/API-strategie-mod-geo/appendix.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/appendix.md
@@ -18,19 +18,19 @@ Request and response may be based on another coordinate reference system. This a
 
 |HTTP header|Value|Explanation|
 |-|-|-|
-|`Content-Crs`|EPSG:4326|WGS84, global|
+|`Content-Crs`|EPSG:4326|WGS 84, global|
 |`Content-Crs`|EPSG:3857|Pseudo Mercator, global|
 |`Content-Crs`|EPSG:4258|ETRS89, European|
-|`Content-Crs`|EPSG:28992|RD/Amersfoort, Dutch|
+|`Content-Crs`|EPSG:28992|RD, Dutch|
 
 The preferred CRS for the geometry in the response (response body) is specified using the header `Accept-Crs`.
 
 |HTTP header|Value|Explanation|
 |-|-|-|
-|`Accept-Crs`|EPSG:4326|WGS84, global|
+|`Accept-Crs`|EPSG:4326|WGS 84, global|
 |`Accept-Crs`|EPSG:3857|Pseudo Mercator, global|
 |`Accept-Crs`|EPSG:4258|ETRS89, European|
-|`Accept-Crs`|EPSG:28992|RD/Amersfoort, Dutch|
+|`Accept-Crs`|EPSG:28992|RD, Dutch|
 
 <p class="rulelab"><strong>Rule</strong>: Use content negotiation to serve different CRSs</p>
   <p>The CRS for the geometry in the response body is defined using the <code>Accept-Crs</code> header. In case the API does not support the requested CRS, send the HTTP status code <code>406 Not Acceptable</code>.</p>

--- a/API-strategie-modulen/API-strategie-mod-geo/appendix.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/appendix.md
@@ -2,7 +2,7 @@
 
 ## Old CRS negotiation method
 
-An older method of specifying CRS in the headers of requests is described in this appendix. It was part of the first version of the "Geospatial Extension" which was never ratified. APIs that already support this old header method can add support for the current parameter method [TODO add ref] while still supporting the header method for a certain period. Supporting both the new method (using parameters) and the old (using headers) is trivial. 
+An older method of specifying CRS in the headers of requests is described in this appendix. It was part of the first version of the "Geospatial Extension" which was never ratified. APIs that already support this old header method can add support for the current parameter method (see [CRS negotiation](./crs.md#crs-negotiation)) while still supporting the header method for a certain period. Supporting both the new method (using parameters) and the old (using headers) is trivial. 
 
 If a client specifies CRS using a parameter AND in the header, the parameter takes precedence and the CRS in the header is ignored.
 

--- a/API-strategie-modulen/API-strategie-mod-geo/appendix.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/appendix.md
@@ -18,8 +18,8 @@ Request and response may be based on another coordinate reference system. This a
 
 |HTTP header|Value|Explanation|
 |-|-|-|
-|`Content-Crs`|EPSG:4326|WGS 84, global|
-|`Content-Crs`|EPSG:3857|Pseudo Mercator, global|
+|`Content-Crs`|EPSG:4326|CRS84, global|
+|`Content-Crs`|EPSG:3857|WGS 84 Pseudo Mercator, global|
 |`Content-Crs`|EPSG:4258|ETRS89, European|
 |`Content-Crs`|EPSG:28992|RD, Dutch|
 
@@ -27,8 +27,8 @@ The preferred CRS for the geometry in the response (response body) is specified 
 
 |HTTP header|Value|Explanation|
 |-|-|-|
-|`Accept-Crs`|EPSG:4326|WGS 84, global|
-|`Accept-Crs`|EPSG:3857|Pseudo Mercator, global|
+|`Accept-Crs`|EPSG:4326|CRS84, global|
+|`Accept-Crs`|EPSG:3857|WGS 84 Pseudo Mercator, global|
 |`Accept-Crs`|EPSG:4258|ETRS89, European|
 |`Accept-Crs`|EPSG:28992|RD, Dutch|
 

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -55,7 +55,7 @@ The default CRS for GeoJSON and for OGC API Features is WGS 84 with coordinate o
 When referring to a coordinate reference system using its code in the rest of this chapter, this is meant to refer to both the 2D and 3D variant of the system in question. E.g. when "RD" is mentioned, this should be taken to mean "RD or RD-NAP"; when WGS 84 is mentioned, this should be taken to mean "CRS84 or CRS84h". 
 </aside>
 
-Since most client-side mapping libraries use WGS 84, the W3C/OGC [Spatial Data on the Web](https://www.w3.org/2021/sdw/) working group recommends to use this as the default coordinate reference system. Thus, spatial data can be mapped without any complex transformations. The API strategy caters for this supporting not only ETRS89 and RD, but also WGS 84 and Pseudo Mercator (EPSG:3857).
+Since most client-side mapping libraries use WGS 84, the W3C/OGC [Spatial Data on the Web](https://www.w3.org/2021/sdw/) working group recommends to use this as the default coordinate reference system. Thus, spatial data can be mapped without any complex transformations. The API strategy caters for this supporting not only ETRS89 and RD, but also CRS84.
 
 The *default* CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. 
 

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -49,13 +49,13 @@ If all features in a feature collection are stored using a particular CRS, the p
 
 ## CRS negotiation
 
-The default CRS for GeoJSON and for OGC API Features is WGS84 with coordinate order longitude-latitude, also referred to as "CRS84". This is the global CRS that can be applied world-wide. Due to the datum and the tectonic displacements it is not accurate enough for local coordinate reference systems like ETRS89 (EPSG:4258, European), or RD/Amersfoort (EPSG:28992, Dutch). For more information about coordinate reference systems, read the Geonovum guidelines on CRS [[hr-crs]].
+The default CRS for GeoJSON and for OGC API Features is WGS 84 with coordinate order longitude-latitude, also referred to as "CRS84". This is the global CRS that can be applied world-wide. Due to the datum and the tectonic displacements it is not accurate enough for local coordinate reference systems like ETRS89 (EPSG:4258, European), or RD (EPSG:28992, Dutch). For more information about coordinate reference systems, read the Geonovum guidelines on CRS [[hr-crs]].
 
 <aside class="note" title="Convention">
-When referring to a coordinate reference system using its code in the rest of this chapter, this is meant to refer to both the 2D and 3D variant of the system in question. E.g. when "RD" is mentioned, this should be taken to mean "RD or RD-NAP"; when WGS84 is mentioned, this should be taken to mean "WGS84 or WGS84h". 
+When referring to a coordinate reference system using its code in the rest of this chapter, this is meant to refer to both the 2D and 3D variant of the system in question. E.g. when "RD" is mentioned, this should be taken to mean "RD or RD-NAP"; when WGS 84 is mentioned, this should be taken to mean "CRS84 or CRS84h". 
 </aside>
 
-Since most client-side mapping libraries use WGS84, the W3C/OGC [Spatial Data on the Web](https://www.w3.org/2021/sdw/) working group recommends to use this as the default coordinate reference system. Thus, spatial data can be mapped without any complex transformations. The API strategy caters for this supporting not only ETRS89 and RD/Amersfoort, but also WGS84 and Pseudo Mercator (EPSG:3857).
+Since most client-side mapping libraries use WGS 84, the W3C/OGC [Spatial Data on the Web](https://www.w3.org/2021/sdw/) working group recommends to use this as the default coordinate reference system. Thus, spatial data can be mapped without any complex transformations. The API strategy caters for this supporting not only ETRS89 and RD, but also WGS 84 and Pseudo Mercator (EPSG:3857).
 
 The *default* CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. 
 
@@ -87,9 +87,9 @@ The guiding principles for CRS support:
 - The default CRS, CRS84, is listed first in the list of supported CRSs in the API; if the consumer does not specify the CRS it is assumed it uses the default.
 - Coordinate reference systems API strategy: request/response in RD; ETRS89; CRS84; Pseudo  Mercator;
 - Consider no-regret: record in multiple much-requested CRSs instead of on-the-fly transformation;
-- Use RDNAPTRANS™ 2018 to transform RD/Amersfoort to ETRS89 (correction grid);
+- Use RDNAPTRANS™ 2018 to transform RD to ETRS89 (correction grid);
 - Presentation depending on context (e.g. user requirements);
-- Exchange format (notation) ETRS89 and WGS84 longitude latitude in decimal degrees: DD.ddddddddd (for example: `5.962376256, 52.255023450`)
+- Exchange format (notation) ETRS89 and WGS 84 longitude latitude in decimal degrees: DD.ddddddddd (for example: `5.962376256, 52.255023450`)
 - Exchange format (notation) RD and Pseudo Mercator X Y in meters: `195427.5200 311611.8400`
 
 The CRS can be specified for request and response individually using parameters or headers.
@@ -162,20 +162,20 @@ The API should be able to handle the following scenarios based on the rules stat
 
 Use the following URIs to specify the CRS:
 
-|Name|Dimension|Scope|URI|
+| Name | Dimension | Scope | URI |
 |-|-|-|-|
-|Amersfoort / RD New | 2D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/28992|
-|Amersfoort / RD New + NAP height | 3D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/7415|
-|ETRS89 | 2D | European | http://www.opengis.net/def/crs/EPSG/9.9.1/4258|
-|ETRS89 | 3D | European | http://www.opengis.net/def/crs/EPSG/9.9.1/4937|
-|WGS 84 longitude-latitude | 2D | Global | http://www.opengis.net/def/crs/OGC/1.3/CRS84|
-|WGS 84 longitude-latitude-height | 3D | Global | http://www.opengis.net/def/crs/OGC/0/CRS84h |
-|WGS 84 / Pseudo-Mercator | 2D | Global | http://www.opengis.net/def/crs/EPSG/9.9.1/3857|
+| Amersfoort / RD New | 2D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/28992 |
+| Amersfoort / RD New + NAP height | 3D | Dutch | http://www.opengis.net/def/crs/EPSG/9.9.1/7415 |
+| ETRS89 | 2D | European | http://www.opengis.net/def/crs/EPSG/9.9.1/4258 |
+| ETRS89 | 3D | European | http://www.opengis.net/def/crs/EPSG/9.9.1/4937 |
+| WGS 84 longitude-latitude | 2D | Global | http://www.opengis.net/def/crs/OGC/1.3/CRS84 |
+| WGS 84 longitude-latitude-height | 3D | Global | http://www.opengis.net/def/crs/OGC/0/CRS84h |
+| WGS 84 / Pseudo-Mercator | 2D | Global | http://www.opengis.net/def/crs/EPSG/9.9.1/3857 |
 
 <aside class="note" title="CRS support and GeoJSON">
-Officially, WGS84 lat-long (CRS84) is the only CRS allowed in GeoJSON. However, GeoJSON does state that using another CRS is allowed, if this is agreed between provider and consumer of the data. The API functionality described above, to negotiate the CRS between client and server, can be viewed as such an agreement. Many GIS clients can deal with GeoJSON in other CRS than CRS84.
+Officially, WGS 84 lat-long (CRS84) is the only CRS allowed in GeoJSON. However, GeoJSON does state that using another CRS is allowed, if this is agreed between provider and consumer of the data. The API functionality described above, to negotiate the CRS between client and server, can be viewed as such an agreement. Many GIS clients can deal with GeoJSON in other CRS than CRS84.
 
-In addition, the Geonovum CRS guidelines [[hr-crs]] describe [how ETRS89 can be treated as equal to WGS84 under certain circumstances](https://docs.geostandaarden.nl/crs/cv-hr-crs-20211125/#wgs-84-gelijkstellen-aan-etrs89) - but note that GeoJSON requires coordinates to be in latitude-longitude order, while ETRS89 uses longitude-latitude. 
+In addition, the Geonovum CRS guidelines [[hr-crs]] describe [how ETRS89 can be treated as equal to WGS 84 under certain circumstances](https://docs.geostandaarden.nl/crs/cv-hr-crs-20211125/#wgs-84-gelijkstellen-aan-etrs89) - but note that GeoJSON requires coordinates to be in latitude-longitude order, while ETRS89 uses longitude-latitude. 
 
 [[JSON-FG]] is a proposed standard extension of GeoJSON that adds CRS support.
 </aside>

--- a/API-strategie-modulen/API-strategie-mod-geo/introduction.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/introduction.md
@@ -4,13 +4,16 @@ This document provides rules for publishing geospatial data using Web APIs. Spat
 
 > data that describes anything with spatial extent (i.e. size, shape or position). Spatial data is also known as location information. [[sdw-bp]]
 
-Geospatial data is a bit more specific in that it is explicitly located relative to the Earth. 
+Geospatial data is more specific in that it is explicitly located relative to the Earth. 
 
-Geospatial data is 'special' data in the sense that it typically indicates the location of things using geometry. This geometry allows specific geospatial functions such as 'find only the things located within this area' but also requires specific ways of handling. There are specific international regulations and standards for geospatial data that need to be taken into account in certain cases.
+Geospatial data is 'special' data in the sense that it typically indicates the location of things using geometry. This geometry allows geospatial functions such as 'find only the things located within this area' but also requires specific ways of handling. There are international regulations and standards for geospatial data that need to be taken into account in certain cases.
 
 <figure>
     <img alt="castle features shown on map with bounding box" src="media/boundingbox.png"/>
     <figcaption>The red bounding box acts as a filter to find only the castles located within this area</figcaption>
 </figure>
 
-The Geospatial Module gives the rules for the structuring of geospatial payloads and for functions specific for geospatial data in APIs.
+The Geospatial Module provides rules for the structuring of geospatial payloads and for functions in APIs to handle geospatial data.
+
+
+In the geospatial module the abbreviation RD is used. RD refers to the "Stelsel van de Rijksdriehoeksmeting", this is the equivalent of EPSG code 28992 and EPSG name Amersfoort / RD New.

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -3,7 +3,7 @@ REST APIs for handling geospatial features may provide spatial filtering. There 
 
 ## GeoJSON
 
-[[rfc7946]] describes the GeoJSON format, including a convention for describing 2D geometric objects in WGS84 (EPSG:4326). In this extension we adopt the GeoJSON conventions for describing geometry objects. The convention is extended to allow alternative projections.  
+[[rfc7946]] describes the GeoJSON format, including a convention for describing 2D geometric objects in WGS 84 (CRS84). In this extension we adopt the GeoJSON conventions for describing geometry objects. The convention is extended to allow alternative projections.  
 
 <div class="rule" id="api-geo-1">
   <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
@@ -32,7 +32,7 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
   <p class="rulelab"><strong>API-GEO-2</strong>: Supply a simple spatial filter as a bounding box parameter</p>
   <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> parameter</a> in conformance to the standard.
   <pre>
-   GET /api/v1/panden?bbox=5.4,52.1,5.5,53.2</pre>
+   GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2</pre>
   </p>
   <h4 class="rulelab">How to test</h4>
   <ul>


### PR DESCRIPTION
Hoofdstuk 1 Introductie: tekstueel: "a bit more" is informeel -> "more"  
[MSR] done

Hoofdstuk 1 Introductie: tekstueel: woord "specific" wordt te vaak gebruikt
[MSR] done

Gehele tekst: De officiële naam is niet "WGS84", maar "WGS 84". 
[MSR] done

Gehele tekst: "ETRS89 (EPSG:4258)" is een onnauwkeurige ensemblecode, het is beter om uitsluitend "ETRF2000 (EPSG:9067)" te gebruiken.
[MSR] zoals besproken i.v.m. andere issues, niet aangepast.

Gehele tekst: "Amersfoort" is geen onderdeel van de officiële naam van het "Stelsel van de Rijksdriehoeksmeting" (RD). Consistente naamgeving door het hele document, als er verwezen wordt naar EPSG namen, dit expliciet benoemen.
[MSR] done

Ik mis het gebruik van RFC 2119 voor keywords als MAY, MUST, SHOULD etc.
[MSR] deze zou ik niet op module maar op hoofdniveau verwerken, anders krijg je in iedere module dezelfde tekst wat e.e.a. moeilijker onderhoudbaar maakt.

Onduidelijk welk gedeelte van deze tekst normatief is en welk gedeelte enkel informatief is.
[MSR] op generiek niveau bespreken hoe hiermee om te gaan.

Tekst is in het Engels, maar veel voorbeelden hebben Nederlandse termen. Waarom niet alles in het Engels? Dat maakt het geheel veel leesbaarder. bijv. api/v1/buildings ipv api/v1/panden
[MSR] op generiek niveau bespreken hoe hiermee om te gaan.

"To do" verwijderen
[MSR] done

WGS 84 wordt soms gebruikt waar expliciet CRS84 bedoeld wordt. Of overal WGS84 vervangen door CRS84 waar CRS84 wordt bedoeld. Waar WGS 84 pseudo mercator staat mag wel WGS 84 blijven staan.
[MSR] done
