### PR TITLE
fix for #496

### DIFF
--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -56,6 +56,8 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
 Spatial filtering is an extensive topic. There are use cases for geospatial operators like <code>intersects</code> or <code>within</code>. Geospatial filters can be large and complex, which sometimes causes problems since <code>GET</code> may not have a payload (although supported by some clients). 
 
 More complex spatial filtering is not addressed in this module. A new API Design Rules module on filtering will address spatial as well as non-spatial filtering. [[ogcapi-features-3]] will provide input for this.
+
+However, until the filtering module is written, the geospatial module retains rule API-GEO-3 about dealing with results of a global spatial query. This rule may be moved to the filtering module at a later stage.
 </aside>
 
 <div class="rule" id="api-geo-3">


### PR DESCRIPTION
> issue 496: globaal zoeken op typering hoort niet thuis in de geo module

Klopt, dit hoort eigenlijk in de nog niet bestaande filtering module. We willen de regel zolang die module niet geschreven is, niet verwijderen. Ik heb in de tekst een opmerking toegevoegd met de strekking dat zolang in de ADR niet centraal beschreven is hoe filtering/globaal zoeken werkt, we deze regel in stand houden.