### PR TITLE
Issue/493 post

### DIFF
--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -128,7 +128,7 @@ The CRS can be specified for request and response individually using parameters 
   <p>Perform the same test  for the <code>filter-crs</code> parameter, if the server supports other types of geospatial filters.</p>
 </div>
 
-In an API that supports transactions, POST requests with geospatial content in the body may be sent by a client to the server. In that case, it is necessary to indicate the CRS used, unless CRS84, the default CRS, is used.
+In an API that supports the creation of items, POST requests with geospatial content in the body may be sent by a client to the server. In that case, it is necessary to indicate the CRS used, unless CRS84, the default CRS, is used.
 
 <div class="rule" id="api-geo-11">
   <p class="rulelab"><strong>API-GEO-11</strong>: When HTTP POST requests are supported, pass the coordinate reference system (CRS) of geometry in the request body as a header</p>

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -138,7 +138,7 @@ In an API that supports the creation of items, POST requests with geospatial con
   <p>In a request (i.e. when creating an item on the server):</p>
   <uL>
     <li>Issue an HTTP POST request to the API with spatial data in the request body, including the <code>Content-Crs</code> header with the value of the CRS identifier for the spatial data in the body.</li>
-    <li>Verify that a document was returned with a status code 201.</li>
+    <li>Verify that a document was returned with status code <code>201</code> in case a new item was created, or with status code <code>200</code>.</li>
   </ul>
 </div>
 


### PR DESCRIPTION
Over `transactions`: ik denk dat hier eigenlijk bedoeld wordt dat het via een HTTP POST mogelijk is om items op de server te manipuleren (create, update, replace). Omdat in het testscenario het aanmaken van een item genoemd wordt, lijkt me dat een betere tekst dan `transactions`

Over HTTP `201`: [deze status](https://www.rfc-editor.org/rfc/rfc7231#section-6.3.2) geeft expliciet aan dat een nieuwe resource is gemaakt. Dat is in het geval van een REST API de bedoeling, maar een ander soort API zou ook HTTP `200` kunnen gebruiken om succes aan te geven. Vandaar mijn uitbreiding

Issue #493