### PR TITLE
test description improvements

### DIFF
--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -70,6 +70,7 @@ The *default* CRS, i.e. the CRS which is assumed when not specified by either th
   <h4 class="rulelab">How to test</h4>
   <ul>
     <li>Issue an HTTP GET request to retrieve some spatial data from the API without specifying a coordinate reference system.</li>
+    <li>Validate that the response includes a <code>Content-Crs</code> header with the URI for CRS84 or CRS84h.</li>
     <li>Validate the retrieved spatial data using the CRS84 reference system (for 2D geometries) or the CRS84h reference system (for 3D geometries).</li>
   </ul>
 </div>
@@ -82,6 +83,7 @@ In addition, support for ETRS89 and/or RD is required.
   <h4 class="rulelab">How to test</h4>
   <ul>
     <li>Issue an HTTP GET request to retrieve some spatial data from the API, specifying ETRS89 and/or RD as coordinate reference system.</li>
+    <li>Validate that the response includes a <code>Content-Crs</code> header with the URI for the requested CRS.</li>
     <li>Validate the retrieved spatial data using the coordinate reference system used in the request.</li>
   </ul>  
 </div>
@@ -128,7 +130,7 @@ The CRS can be specified for request and response individually using parameters 
   <uL>
     <li>Issue an HTTP GET request to the API, including the <code>bbox</code> parameter AND the <code>bbox-crs</code> parameter.</li>
     <li>Validate that a document was returned with a status code 200.</li>
-    <li>Verify that the response includes a <code>Content-Crs</code> http header with the value of the requested CRS identifier.</li>
+    <li>Verify that the response includes a <code>Content-Crs</code> http header with the URI of the requested CRS identifier.</li>
   </ul>
   <p>Perform the same test  for the <code>filter-crs</code> parameter, if the server supports other types of geospatial filters.</p>
 </div>
@@ -165,7 +167,7 @@ In an API that supports the creation of items, POST requests with geospatial con
   <h4 class="rulelab">How to test</h4>
   <uL>
     <li>Issue an HTTP GET request to the API, requesting spatial data.</li>
-    <li>Verify that the response includes the <code>Content-Crs</code> header with the value of the requested CRS identifier if explicitly requested, or with the value <code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code> if no CRS was explicitly requested.</li>
+    <li>Verify that the response includes the <code>Content-Crs</code> header with the URI of the requested CRS identifier if explicitly requested, or with the value <code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code> if no CRS was explicitly requested.</li>
   </ul>
 </div>
 

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -5,7 +5,7 @@ A Coordinate Reference System (CRS) or Spatial Reference System (SRS) is a frame
 CRSs are uniquely identified by means of a Spatial Reference System Identifier (SRID).
 SRIDs may refer to different standards, for example EPSG Geodetic Parameter Dataset or Open Geospatial Consortium (OGC).
 
-CRSs may be grouped into ensemble CRSs. The CRSs that are part of an ensemble CRS are called ensemble member CRSs or member CRSs. When exchanging geometry an ensemble member CRS shall be used instead of an ensemble CRS where possible and if accurate data is required. When transforming geometry from one CRS to another, use an ensemble member CRS (instead of an ensemble CRS) as input and output of coordinate transformation, where possible and if accurate data is required.
+CRSs may be grouped into ensemble CRSs. The CRSs that are part of an ensemble CRS are called ensemble member CRSs or member CRSs. When exchanging geometry an ensemble member CRS shall be used instead of an ensemble CRS when known and if accurate data is required. When transforming geometry from one CRS to another, use an ensemble member CRS (instead of an ensemble CRS) as input and output of coordinate transformation, when known and if accurate data is required.
 
 For a detailed description of CRSs see [[hr-crs]].
 
@@ -97,8 +97,8 @@ The guiding principles for CRS support:
 - Exchange format (notation) for RD (X, Y) in meters, for example: (`195427.520, 311611.840`). The X and Y coordinates are decimal numbers. The number of decimals in the fractional part may vary depending on the required accuracy. For an accuracy of 1 mm, 3 decimal places in the fractional part are sufficient. See [Nauwkeurigheid van coördinaten](https://docs.geostandaarden.nl/crs/crs/#nauwkeurigheid-van-coordinaten) in [[hr-crs]].
 - WGS 84 Pseudo Mercator (EPSG:3857) is rather inaccurate, but suitable for simple visualization of inprecise spatial data on the web, e.g. when it suffices if the data is recognizable on a map. WGS 84 Pseudo Mercator shall not be used for precise data that is meant for accurate spatial analysis.
 - Use the CRS Guidelines [[hr-crs]] for coordinate transformations.
-- Use an ensemble member CRS (instead of an ensemble CRS) when exchanging geometry, where possible.
-- Use an ensemble member CRS (instead of an ensemble CRS) as output of coordinate transformation, where possible.
+- Use an ensemble member CRS (instead of an ensemble CRS) for exchanging geometry, when known.
+- Use an ensemble member CRS (instead of an ensemble CRS) as output of coordinate transformation, when known.
 - APIs shall support and advertise both ensemble CRSs and ensemble member CRSs if geometry is exchanged and the CRS for the geometry is an ensemble member CRS.
 - under certain conditions WGS 84 can be made equal to e.g. ETRS89, this is called a nultransformation, see [[hr-crs]]. If a nultransformation is used to realize WGS 84, then the CRS (e.g. ETRS89) that is used to realize WGS 84 shall be supported and advertised by an API.
 

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -17,9 +17,10 @@ A client shall be able to determine a list of CRSs supported by an API.
   // GET /api/v1/collections:</pre>
   <h4 class="rulelab">How to test</h4>
 <ul>
-  <li>Send a request to the <code>/collections</code> endpoint.</li>
+  <li>Issue an HTTP GET request to the <code>/collections</code> endpoint of the API.</li>
   <li>Validate that the returned document contains a <code>collections</code> object with the <code>crs</code> property.</li>
   <li>Validate that the <code>crs</code> property contains an array with CRS references in the form of URIs.</li>
+  <li>Validate that the CRS URIs return a GML document with an <code>epsg:CommonMetadata</code> element (<code>xmlns:epsg="urn:x-ogp:spec:schema-xsd:EPSG:1.0:dataset</code></li>
 </ul>
 </div>
 
@@ -37,11 +38,13 @@ If a feature collection supports a different set of CRSs than the set defined in
 For clients, it may be helpful to know the CRS identifier that may be used to retrieve features from that collection without the need to apply a CRS transformation.
 
 <div class="rule" id="api-geo-6">
-  <p class="rulelab"><strong>API-GEO-6</strong>: Make known in which CRS the geospatial data is stored.</p>
+  <p class="rulelab"><strong>API-GEO-6</strong>: Make known in which CRS the geospatial data is stored by specifying the property <code>storageCrs</code> in the collection object. </p>
+  <p>The value of this property shall be one of the CRSs the API supports.</p> 
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Request each collection in the <code>/collections</code> endpoint.</li>
+    <li>Issue an HTTP GET request to each collection in the <code>/collections</code> endpoint of the API.</li>
     <li>Validate that each returned collection contains the <code>storageCRS</code> property.</li>
+    <li>Validate that the value of the <code>storageCRS</code> property is one of the URIs from the list of supported CRSs.</li>
   </ul>
 </div>
 
@@ -64,7 +67,7 @@ The *default* CRS, i.e. the CRS which is assumed when not specified by either th
   <p>The implication of this is, that if no CRS is explicitly included in the request, CRS84 is assumed. This rule also applies if the request uses POST.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Request spatial data from the API without specifying a coordinate reference system.</li>
+    <li>Issue an HTTP GET request to retrieve some spatial data from the API without specifying a coordinate reference system.</li>
     <li>Validate the retrieved spatial data using the CRS84 reference system (for 2D geometries) or the CRS84h reference system (for 3D geometries).</li>
   </ul>
 </div>
@@ -76,7 +79,7 @@ In addition, support for ETRS89 and/or RD is required.
   <p>General usage of the European ETRS89 coordinate reference system (CRS) or RD/NAP is preferred, but is not the default CRS. Hence, one of these CRSs has to be explicitly included in each request when one of these CRSs is desired in the response or used in a request.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Request spatial data from the API, specifying ETRS89 and/or RD as coordinate reference system.</li>
+    <li>Issue an HTTP GET request to retrieve some spatial data from the API, specifying ETRS89 and/or RD as coordinate reference system.</li>
     <li>Validate the retrieved spatial data using the coordinate reference system used in the request.</li>
   </ul>  
 </div>
@@ -101,7 +104,7 @@ The guiding principles for CRS support:
   <p class="rulelab"><strong>API-GEO-9</strong>: When the API provides data in an ensemble CRS like WGS 84 or ETRS89 while it is known to what ensemble member CRS the data actually refers, this ensemble member should also be one of the CRSs supported by the API and advertised in the CRS list. E.g. when 2D data is transformed from RD with RDNAPTRANS not only EPSG:4258 should be supported but also EPSG::9067.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Send a request to the <code>/collections</code> endpoint.</li>
+    <li>Issue an HTTP GET request to the <code>/collections</code> endpoint.</li>
     <li>Validate that the returned document contains a <code>collections</code> object with the <code>crs</code> property.</li>
     <li>Validate that the <code>crs</code> property contains an array with CRS references in the form of URIs.</li>
     <li>Validate that when the <code>crs</code> property contains a URL for a ensemble CRS like ETRS89 (EPSG:4258), it also contains a URL for a ensemble member CRS like ETRF2000 (EPSG:9067).</li>
@@ -123,7 +126,7 @@ The CRS can be specified for request and response individually using parameters 
   <uL>
     <li>Issue an HTTP GET request to the API, including the <code>bbox</code> parameter AND the <code>bbox-crs</code> parameter.</li>
     <li>Validate that a document was returned with a status code 200.</li>
-    <li>Verify that the geometries in the document have the coordinate reference system that was requested using the <code>bbox-crs</code> parameter.</li>
+    <li>Verify that the response includes a <code>Content-Crs</code> http header with the value of the requested CRS identifier.</li>
   </ul>
   <p>Perform the same test  for the <code>filter-crs</code> parameter, if the server supports other types of geospatial filters.</p>
 </div>
@@ -159,8 +162,8 @@ In an API that supports the creation of items, POST requests with geospatial con
   </p>
   <h4 class="rulelab">How to test</h4>
   <uL>
-    <li>Issue an HTTP GET request to the API, requesting spatial data in a CRS supported by the server using the <code>crs</code> parameter.</li>
-    <li>Verify that the response includes the <code>Content-Crs</code> header with the value of the requested CRS identifier.</li>
+    <li>Issue an HTTP GET request to the API, requesting spatial data.</li>
+    <li>Verify that the response includes the <code>Content-Crs</code> header with the value of the requested CRS identifier if explicitly requested, or with the value <code>http://www.opengis.net/def/crs/OGC/1.3/CRS84</code> if no CRS was explicitly requested.</li>
   </ul>
 </div>
 

--- a/API-strategie-modulen/API-strategie-mod-geo/crs.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/crs.md
@@ -5,6 +5,8 @@ A Coordinate Reference System (CRS) or Spatial Reference System (SRS) is a frame
 CRSs are uniquely identified by means of a Spatial Reference System Identifier (SRID).
 SRIDs may refer to different standards, for example EPSG Geodetic Parameter Dataset or Open Geospatial Consortium (OGC).
 
+CRSs may be grouped into ensemble CRSs. The CRSs that are part of an ensemble CRS are called ensemble member CRSs or member CRSs. When exchanging geometry an ensemble member CRS shall be used instead of an ensemble CRS where possible and if accurate data is required. When transforming geometry from one CRS to another, use an ensemble member CRS (instead of an ensemble CRS) as input and output of coordinate transformation, where possible and if accurate data is required.
+
 For a detailed description of CRSs see [[hr-crs]].
 
 ## CRS discovery
@@ -95,7 +97,7 @@ The guiding principles for CRS support:
 - Exchange format (notation) for RD (X, Y) in meters, for example: (`195427.520, 311611.840`). The X and Y coordinates are decimal numbers. The number of decimals in the fractional part may vary depending on the required accuracy. For an accuracy of 1 mm, 3 decimal places in the fractional part are sufficient. See [Nauwkeurigheid van coördinaten](https://docs.geostandaarden.nl/crs/crs/#nauwkeurigheid-van-coordinaten) in [[hr-crs]].
 - WGS 84 Pseudo Mercator (EPSG:3857) is rather inaccurate, but suitable for simple visualization of inprecise spatial data on the web, e.g. when it suffices if the data is recognizable on a map. WGS 84 Pseudo Mercator shall not be used for precise data that is meant for accurate spatial analysis.
 - Use the CRS Guidelines [[hr-crs]] for coordinate transformations.
-- CRSs may be grouped into ensemble CRSs. When exchanging geometry an ensemble member CRS shall be used (instead of an ensemble CRS) where possible.
+- Use an ensemble member CRS (instead of an ensemble CRS) when exchanging geometry, where possible.
 - Use an ensemble member CRS (instead of an ensemble CRS) as output of coordinate transformation, where possible.
 - APIs shall support and advertise both ensemble CRSs and ensemble member CRSs if geometry is exchanged and the CRS for the geometry is an ensemble member CRS.
 - under certain conditions WGS 84 can be made equal to e.g. ETRS89, this is called a nultransformation, see [[hr-crs]]. If a nultransformation is used to realize WGS 84, then the CRS (e.g. ETRS89) that is used to realize WGS 84 shall be supported and advertised by an API.

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -62,7 +62,7 @@ However, until the filtering module is written, the geospatial module retains ru
 
 <div class="rule" id="api-geo-3">
   <p class="rulelab"><strong>API-GEO-3</strong>: Place results of a global spatial query in the relevant geometric context</p>
-  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different collections, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
+  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/#resources">collections</a>, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
   <pre>
   // POST /api/v1/_search:
   {

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -48,7 +48,7 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
   </p>
   <p> The default spatial operator 'intersects' is used to determine which resources are returned.
   </P>
-  <p> Due to possible performance issue, especially when a combination of filters is used, it is up to the provider to decide to limit the size of the bounding box or the number of results. It is also up to the provider to decide if an error is returned in such cases. 
+  <p> Due to possible performance issue, especially when a combination of filters is used, a provider may decide to limit the size of the bounding box or the number of results. It is also up to the provider to decide if an error is returned in such cases. 
   The provider shall clearly document this behavior.
   </P>
   <p>

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -62,9 +62,9 @@ However, until the filtering module is written, the geospatial module retains ru
 
 <div class="rule" id="api-geo-3">
   <p class="rulelab"><strong>API-GEO-3</strong>: Place results of a global spatial query in the relevant geometric context</p>
-  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different collections are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
+  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://defs.opengis.net/vocprez/object?uri=http%3A//www.opengis.net/def/glossary/term/FeatureCollection">feature collections</a> are retrieved. Express the name of the feature collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
   <pre>
-  // POST /api/v1/_zoek:
+  // POST /api/v1/_search:
   {
     "currentPage": 1,
     "nextPage": 2,

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -62,7 +62,7 @@ However, until the filtering module is written, the geospatial module retains ru
 
 <div class="rule" id="api-geo-3">
   <p class="rulelab"><strong>API-GEO-3</strong>: Place results of a global spatial query in the relevant geometric context</p>
-  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://defs.opengis.net/vocprez/object?uri=http%3A//www.opengis.net/def/glossary/term/FeatureCollection">feature collections</a> are retrieved. Express the name of the feature collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
+  <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different collections, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
   <pre>
   // POST /api/v1/_search:
   {

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -17,11 +17,11 @@ This module does not describe how to supply a geometry as part of a resource for
 
 <div class="rule" id="api-geo-1">
   <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
-  <p>For representing 2D geometric information in an API, preferably use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. </p>
+  <p>For representing 2D geometric information in an API, preferably use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. Use the templates OGC provides for the definition of the schemas for the GeoJSON responses in OpenAPI definitions. These are available at <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureCollectionGeoJSON.yaml">featureCollectionGeoJSON.yaml</a> and <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml">featureGeoJSON.yaml</a>. </p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Request a resource that includes feature content (i.e., coordinates) with response media type of <code>application/geo+json</code>. This must be answered with a 200-response.</li>
-    <li>Validate that the returned document is a GeoJSON document.</li>  
+    <li>Issue an HTTP GET request to the API and request a resource that includes feature content (i.e., coordinates) with response media type of <code>application/geo+json</code>. This must be answered with a 200-response.</li>
+    <li>Validate that the returned document is a GeoJSON document using the OGC schema definitions <code>featureCollectionGeoJSON.yaml</code> and <code>featureGeoJSON.yaml</code>.</li>
   </ul>
 </div>
 
@@ -91,7 +91,10 @@ However, until the filtering module is written, the geospatial module retains ru
     }
   }</pre>
   <h4 class="rulelab">How to test</h4>
-  <p>Validate that the returned document contains the expected <code>type</code> property for each member.</p>
+  <ul>
+    <li>Issue an HTTP GET request to the API.</li>
+    <li>Validate that the returned document contains the expected <code>type</code> property for each member.</li>
+  </ul>
 </div>
 
 ## Result (response)
@@ -110,7 +113,7 @@ In a REST API that uses JSON as the data format, the geometry is returned as a G
     }
   }</pre>
   <h4 class="rulelab">How to test</h4>
-  <p>Validate that the returned document represents coordinates using: </p>
+  <p>Issue an HTTP GET request to the API. Validate that the returned document represents coordinates using: </p>
   <ul>
     <li>a property <code>type</code> containing the name of one of the GeoJSON geometry types, and</li>
     <li>a property <code>coordinates</code> containing an array with a minimum of 2 numbers.</li>

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -125,7 +125,7 @@ In a REST API that uses JSON as the data format, the geometry is returned as a G
     }
   }</pre>
   <h4 class="rulelab">How to test</h4>
-  <p>Issue an HTTP GET request to the API. Validate that the returned document represents coordinates as specified in <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml">geometryGeoJSON.yaml</a>, i.e. using: </p>
+  <p>Issue an HTTP GET request to the API. Validate that the returned document represents geometry as specified in <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml">geometryGeoJSON.yaml</a>, i.e. using: </p>
   <ul>
     <li>a property <code>type</code> containing the name of one of the GeoJSON geometry types, and</li>
     <li>a property <code>coordinates</code> containing an array with a minimum of 2 numbers.</li>

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -40,13 +40,25 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
 
 <div class="rule" id="api-geo-2">
   <p class="rulelab"><strong>API-GEO-2</strong>: Supply a simple spatial filter as a bounding box parameter</p>
-  <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> parameter</a> in conformance to the standard.
+  <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> query parameter</a> in conformance to the standard. 
   <pre>
    GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2</pre>
   </p>
+  <p>Note that if a resource contains multiple geometries, it is up to the provider to decide if a single or multiple geometries are returned and that the provider shall clearly document this behavior.
+  </p>
+  <p> The default spatial operator 'intersects' is used to determine which resources are returned.
+  </P>
+  <p> Due to possible performance issue, especially when a combination of filters is used, it is up to the provider to decide to limit the size of the bounding box or the number of results. It is also up to the provider to decide if an error is returned in such cases. 
+  The provider shall clearly document this behavior.
+  </P>
+  <p>
+  The provider shall be able to provide resources that do not have a geometry property and are related to resources that match the bounding box filter.
+  </p>
+  <p> An error shall be given if the provided coordinates are outside the specified coordinate reference system.
+  </p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> parameter.</li>
+    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> query parameter.</li>
     <li>Validate that a document was returned with a status code 200.</li>
     <li>Verify that only features that have a spatial geometry that intersects the bounding box are returned as part of the result set.</li>
   </ul>

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -17,11 +17,11 @@ This module does not describe how to supply a geometry as part of a resource for
 
 <div class="rule" id="api-geo-1">
   <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
-  <p>For representing 2D geometric information in an API, preferably use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. Use the templates OGC provides for the definition of the schemas for the GeoJSON responses in OpenAPI definitions. These are available at <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureCollectionGeoJSON.yaml">featureCollectionGeoJSON.yaml</a> and <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml">featureGeoJSON.yaml</a>. </p>
+  <p>For representing 2D geometric information in an API, preferably use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. Use the templates OGC provides for the definition of the schemas for the GeoJSON responses in OpenAPI definitions. These are available at <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureCollectionGeoJSON.yaml">featureCollectionGeoJSON.yaml</a>, <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureGeoJSON.yaml">featureGeoJSON.yaml</a> and <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml">geometryGeoJSON.yaml</a>. </p>
   <h4 class="rulelab">How to test</h4>
   <ul>
     <li>Issue an HTTP GET request to the API and request a resource that includes feature content (i.e., coordinates) with response media type of <code>application/geo+json</code>. This must be answered with a 200-response.</li>
-    <li>Validate that the returned document is a GeoJSON document using the OGC schema definitions <code>featureCollectionGeoJSON.yaml</code> and <code>featureGeoJSON.yaml</code>.</li>
+    <li>Validate that the returned document is a GeoJSON document using the OGC schema definitions <code>featureCollectionGeoJSON.yaml</code>, <code>featureGeoJSON.yaml</code> and <code>geometryGeoJSON.yaml</code>.</li>
   </ul>
 </div>
 
@@ -125,7 +125,7 @@ In a REST API that uses JSON as the data format, the geometry is returned as a G
     }
   }</pre>
   <h4 class="rulelab">How to test</h4>
-  <p>Issue an HTTP GET request to the API. Validate that the returned document represents coordinates using: </p>
+  <p>Issue an HTTP GET request to the API. Validate that the returned document represents coordinates as specified in <a href="http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml">geometryGeoJSON.yaml</a>, i.e. using: </p>
   <ul>
     <li>a property <code>type</code> containing the name of one of the GeoJSON geometry types, and</li>
     <li>a property <code>coordinates</code> containing an array with a minimum of 2 numbers.</li>


### PR DESCRIPTION
Lost #562 op: n.a.v. commentaar op de 'how to test' formuleringen door de programmeur van de API validator.

Bullet 2, "beschrijf zo mogelijk wat er moet gebeuren als er iets fout gaat" heb ik nog niet meegenomen want dit vond ik moeilijk om te doen, plus denk ik dat de OGC API standaarden dit al wel volledig beschrijven.

Verder denk ik (maar heb dit in deze PR nog niet doorgevoerd) dat de volgorde van regels rondom CRS iets logischer kan. GEO-API-12 en GEO-API-13 zou ik na GEO-API-7 willen zetten. Graag in de review commentaar of jullie hiermee akkoord zijn, dan voer ik dat door.

closes #562