### PR TITLE
Lost #483 op

### DIFF
--- a/API-strategie-modulen/API-strategie-mod-geo/config.js
+++ b/API-strategie-modulen/API-strategie-mod-geo/config.js
@@ -116,14 +116,20 @@ var respecConfig =
       publisher: "Open Geospatial Consortium",
       version: "1.0.0-rc.1"
     },
-     "JSON-FG": {
+    "JSON-FG": {
       href: "https://docs.ogc.org/DRAFTS/21-045.html",
       title: "OGC Features and Geometries JSON - Part 1: Core",
       editors: ["Clemens Portele", "Panagiotis (Peter) A. Vretanos"],
       status: "Editor's Draft",
       publisher: "Open Geospatial Consortium",
       version: "0.1"
-     },
+    },
+    "HAL": {
+      href: "http://stateless.co/hal_specification.html",
+      title: "HAL - Hypertext Application Language",
+      authors: ["Mike Kelly"],
+      date: " 2013-09-18",
+    },
   },
   postProcess:[custGHPG],
 };

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -99,7 +99,7 @@ However, until the filtering module is written, the geospatial module retains ru
 
 ## Result (response)
 
-In case a REST API shall comply to the OGC API Features specifications, e.g. for usage in GIS applications, the following applies.
+In case a REST API shall comply to the OGC API Features specification, e.g. for usage in GIS applications, the following applies.
 
 <div class="rule" id="api-geo-1">
   <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
@@ -164,7 +164,7 @@ In case a REST API shall comply to the OGC API Features specifications, e.g. for
   Note that:
   
   - The resources' properties (e.g. <code>naam</code>) are passed in the properties object. Depending on the implemented filter capabilities the properties object may contain all or a selection of the resources' properties.
-  - The OGC API Fearures specifications provides the possibility to add an array of links to a feature and feature collection, which may contain a self link and in case of a feature collection may contain navigation links.
+  - The OGC API Fearures specification provides the possibility to add an array of links to a feature and feature collection, which may contain a self link and in case of a feature collection may contain navigation links.
   </p>
   <h4 class="rulelab">How to test</h4>
   <p>
@@ -198,14 +198,14 @@ In case a REST API shall comply to the OGC API Features specifications, e.g. for
   Test case 4:
   </p>
   <ul>
-    <li>Request a collection of resource that do not includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Request a collection of resources that do not includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
     <li>Validate that the returned document is a JSON document.</li> 
   </ul>
 </div>
 
-In case a REST API does not have to comply to the OGC API Features specifications, e.g. for usage in administrative applications, the REST API shall use the JSON data format. If resources contain geometry, the geometry shall be returned as a GeoJSON <code>Geometry</code> object embedded in the resource. The media type <code>application/json</code> must be supported. The media type <code>application/geo+json</code> should not be supported while the resource does not comply to the GeoJSON specification, i.e. the response does not return a feature or feature collection.
+In case a REST API does not have to comply to the OGC API Features specification, e.g. for usage in administrative applications, the REST API shall use the JSON data format. If resources contain geometry, the geometry shall be returned as a GeoJSON <code>Geometry</code> object embedded in the resource. The media type <code>application/json</code> must be supported. The media type <code>application/geo+json</code> should not be supported while the resource does not comply to the GeoJSON specification, i.e. the response does not return a feature or feature collection.
 A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the responses in OpenAPI definitions are available [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
 In case a collection of resources is returned, the name of the array containing the resources should be the plural of the resource name.
 
@@ -221,6 +221,26 @@ In case a collection of resources is returned, the name of the array containing 
     "geometrie":  {
       "type": "Point",
       "coordinates": [5.2795,52.1933]
+    },
+    ...,
+    "_links": {
+      {
+        "self": ""
+      }
+    }
+  }</pre>
+
+ Example: resource containing geometry collection
+  <pre>
+  {
+    "identificatie": "0308100000022041",
+    "naam": "Paleis Soestdijk",
+    "geometrie": {
+      "type": "GeometryCollection",
+      "geometries": [
+        "type": "Point"
+        "coordinates": [5.2795,52.1933]
+      ]
     },
     ...,
     "_links": {
@@ -260,7 +280,7 @@ In case a collection of resources is returned, the name of the array containing 
   <p>
   Note that:
   
-  - The resource and resource collection may be [[HAL]] resources and therefor may contain a _links object. The _links object should contain a self link and in case of a collection also navigation links (e.g. first, next prev, last).
+  - The resource and resource collection may be [[HAL]] resources and therefore may contain a _links object. The _links object should contain a self link and in case of a collection also navigation links (e.g. first, next prev, last).
   </p>
   <h4 class="rulelab">How to test</h4>
   <p>
@@ -285,7 +305,7 @@ In case a collection of resources is returned, the name of the array containing 
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
     <li>Validate that the returned document is a JSON document.</li> 
-    <li>Validate that the returned document contains a property that complies to one of the GeoJSON <code>Geometry</code> objects mentioned above and contains:</li>
+    <li>Validate that the returned document contains an array of resources and that each resource contains a property that complies to one of the GeoJSON <code>Geometry</code> objects mentioned above and contains:</li>
     <ul>
       <li>a property <code>type</code> containing the name of one of the GeoJSON <code>Geometry</code> object types mentioned above, and</li>
       <li>a property <code>coordinates</code> containing an array with the coordinates. Depending on the type of geometry object, the content of the array differs.</li>
@@ -299,7 +319,7 @@ In case a collection of resources is returned, the name of the array containing 
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
     <li>Validate that the returned document is a JSON document.</li> 
-    <li>Validate that the returned document contains a property that complies to the GeoJSON <code>Geometry</code> object metntioned above and contains: </li>
+    <li>Validate that the returned document contains a property that complies to the GeoJSON <code>Geometry</code> object mentioned above and contains: </li>
     <ul>
       <li>a property <code>type</code> containing the name of the GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code>, and</li>
       <li>a property <code>geometries</code> containing an array of GeoJSON <code>Geometry</code> objects.</li>
@@ -313,7 +333,7 @@ In case a collection of resources is returned, the name of the array containing 
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
     <li>Validate that the returned document is a JSON document.</li> 
-    <li>Validate that the returned document contains a property that complies to the GeoJSON <code>Geometry</code> object metntioned above and contains: </li>
+    <li>Validate that the returned document contains an array of resources and that each resource contains a  property that complies to the GeoJSON <code>Geometry</code> object mentioned above and contains: </li>
     <ul>
       <li>a property <code>type</code> containing the name of the GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code>, and</li>
       <li>a property <code>geometries</code> containing an array of GeoJSON <code>Geometry</code> objects.</li>

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -8,22 +8,13 @@ Providing requested resources is the essence of any API. This also applies to RE
 When requesting information, for example about cadastral parcels, users do not necessarily require the geometry, even if they used a spatial filter. A name or parcel ID may be sufficient.
 
 <aside class="note">
-This module does not describe how to supply a geometry as part of a resource for storage, i.e. when creating, replacing or updating resources. [OGC API Features part 4](http://docs.ogc.org/DRAFTS/20-002.html), which is still in development, will address this. In general, this would be done using a POST request with `Content-crs` header to indicate the CRS used.
+This module does not describe how to supply a geometry as part of a resource for storage, i.e. when creating, replacing or updating resources. [OGC API Features part 4](http://docs.ogc.org/DRAFTS/20-002.html), which is still in development, will address this. In general, this would be done using a POST request with <code>Content-Crs</code> header to indicate the CRS used.
 </aside>
 
 ## GeoJSON
 
-[[rfc7946]] describes the GeoJSON format, including a convention for describing 2D geometric objects in CRS84. In the Geospatial module of the API strategy we adopt the GeoJSON conventions for describing geometry objects. The convention is extended to allow alternative projections.  
-
-<div class="rule" id="api-geo-1">
-  <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
-  <p>For representing 2D geometric information in an API, preferably use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. </p>
-  <h4 class="rulelab">How to test</h4>
-  <ul>
-    <li>Request a resource that includes feature content (i.e., coordinates) with response media type of <code>application/geo+json</code>. This must be answered with a 200-response.</li>
-    <li>Validate that the returned document is a GeoJSON document.</li>  
-  </ul>
-</div>
+[[rfc7946]] describes the GeoJSON format, including a convention for describing 2D geometric objects in CRS84. In the Geospatial module of the API strategy we adopt the GeoJSON conventions for describing geometry objects. The convention is extended to allow alternative projections.
+The GeoJSON conventions and extensions described in this module apply to both geometry passed in input parameters and responses.
 
 <aside class="note">
 GeoJSON does not cover all use cases. For example, it is not possible to store circular arc geometries or solids in GeoJSON. In such cases, there are several valid options: 
@@ -40,13 +31,12 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
 
 <div class="rule" id="api-geo-2">
   <p class="rulelab"><strong>API-GEO-2</strong>: Supply a simple spatial filter as a bounding box parameter</p>
-  <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> query parameter</a> in conformance to the standard. 
+  <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> query parameter</a> in conformance to the standard.</p> 
   <pre>
-   GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2</pre>
-  </p>
+    GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2</pre>
   <p>Note that if a resource contains multiple geometries, it is up to the provider to decide if a single or multiple geometries are returned and that the provider shall clearly document this behavior.
   </p>
-  <p> The default spatial operator 'intersects' is used to determine which resources are returned.
+  <p> The default spatial operator <code>intersects</code> is used to determine which resources are returned.
   </P>
   <p> Due to possible performance issue, especially when a combination of filters is used, a provider may decide to limit the size of the bounding box or the number of results. It is also up to the provider to decide if an error is returned in such cases. 
   The provider shall clearly document this behavior.
@@ -58,16 +48,24 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
   </p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> query parameter.</li>
-    <li>Validate that a document was returned with a status code 200.</li>
+    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> query parameter and <code>bbox-crs</code> heaeder containing a CRS supported by the provider. If the provider supports CRS84 than the <code>bbox-crs</code> header may be omitted.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
     <li>Verify that only features that have a spatial geometry that intersects the bounding box are returned as part of the result set.</li>
   </ul>
 </div>
+
+TO DO 
+Bovenstaande voorbeeld is redundant met het voorbeeld bij API-GEO-10. Het lijkt me goed om hier het voorbeeld van bbox te gebruiken en bij API-GEO-10 een ander voorbeeld, of vanuit API-GEO-10 te verwijzen naar dit voorbeeld of andersom.
 
 <aside class="note">
 Spatial filtering is an extensive topic. There are use cases for geospatial operators like <code>intersects</code> or <code>within</code>. Geospatial filters can be large and complex, which sometimes causes problems since <code>GET</code> may not have a payload (although supported by some clients). 
 
 More complex spatial filtering is not addressed in this module. A new API Design Rules module on filtering will address spatial as well as non-spatial filtering. [[ogcapi-features-3]] will provide input for this.
+
+TO DO 
+Moet hier een requirement worden opgenomen, dat als er met geometrie gezocht wordt, tenminste GeoJSON <code>Geometry</code> objecten ondersteund moeten worden? Of als de geometrie niet in GeoJSON past (curves etc.) dat dan WKT en WKB ondersteund moeten worden?
+
+Onderstaande hoort hier m.i. niet, maar dat is volgens mij issue #496.
 
 However, until the filtering module is written, the geospatial module retains rule API-GEO-3 about dealing with results of a global spatial query. This rule may be moved to the filtering module at a later stage.
 </aside>
@@ -101,30 +99,240 @@ However, until the filtering module is written, the geospatial module retains ru
         }
       ]
     }
-  }</pre>
+  }
+  </pre>
   <h4 class="rulelab">How to test</h4>
   <p>Validate that the returned document contains the expected <code>type</code> property for each member.</p>
 </div>
 
 ## Result (response)
 
-In a REST API that uses JSON as the data format, the geometry is returned as a GeoJSON Geometry object.
+In case a REST API shall comply to the OGC API Features specifications, e.g. for usage in GIS applications, the following applies.
 
-<div class="rule" id="api-geo-4">
-  <p class="rulelab"><strong>API-GEO-4</strong>: Embed GeoJSON Geometry object as part of the JSON resource</p>
-  <p>When a JSON (<code>application/json</code>) response contains a geometry, represent it in the same way as the <code>Geometry</code> object of GeoJSON.</p>
+<div class="rule" id="api-geo-1">
+  <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
+  <p>For representing 2D geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. </p>
+  Example: feature
   <pre>
   {
-    "naam": "Paleis Soestdijk",
-    "locatie":  {
+    "type": "Feature",
+    "id": "0308100000022041",
+    "geometry":  {
       "type": "Point",
       "coordinates": [5.2795,52.1933]
-    }
-  }</pre>
+    },
+    "properties": {
+      "naam": "Paleis Soestdijk",
+      ...
+    },
+    "links": [
+    {
+      "self": ""
+    } 
+    ]
+  }
+  </pre>
+
+  Example: feature collection
+  <pre>
+  {
+    "type": "FeatureCollection",
+    "features": [
+    {
+      "type": "Feature",
+      "id": "0308100000022041",
+      "geometry":  {
+        "type": "Point",
+        "coordinates": [5.2795,52.1933]
+      },
+      "properties": {
+        "naam": "Paleis Soestdijk",
+        ...
+      },
+      "links": [
+      {
+        "self": ""
+      } 
+      ]
+    }],
+    "timeStamp" : "2023-02-22T10:32:23Z",
+    "numberMatched" : "0308100000022041",
+    "numberReturned" : "1",
+    "links": [
+    {
+      "self": ""
+    } ,
+    {
+      "next": ""
+    } ,
+    ]
+  }
+  </pre>
+  <p>
+  Note that:
+  
+  - The resources' properties (e.g. <code>naam</code>) are passed in the properties object. Depending on the implemented filter capabilities the properties object may contain all or a selection of the resources' properties.
+  - The OGC API Fearures specifications provides the possibility to add an array of links to a feature and feature collection, which may contain a self link and in case of a feature collection may contain navigation links.
+  </p>
   <h4 class="rulelab">How to test</h4>
-  <p>Validate that the returned document represents coordinates using: </p>
+  <p>
+  Test case 1:
+  </p>
   <ul>
-    <li>a property <code>type</code> containing the name of one of the GeoJSON geometry types, and</li>
-    <li>a property <code>coordinates</code> containing an array with a minimum of 2 numbers.</li>
+    <li>Request a single resource that includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/geo+json</code></li> 
+    <li>Validate that the returned document is a GeoJSON Feature document.</li> 
+  </ul>
+  <p>
+  Test case 2:
+  </p>
+  <ul>
+    <li>Request a collection of resources that include feature content (i.e. coordinates) with response media type <code>application/geo+json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/geo+json</code></li> 
+    <li>Validate that the returned document is a GeoJSON FeatureCollection document.</li> 
+  </ul>
+  <p>
+  Test case 3:
+  </p>
+  <ul>
+    <li>Request a single resource that does not include feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
+  </ul>
+  <p>
+  Test case 4:
+  </p>
+  <ul>
+    <li>Request a collection of resource that do not includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
   </ul>
 </div>
+
+In case a REST API does not have to comply to the OGC API Features specifications, e.g. for usage in administrative applications, the REST API shall use the JSON data format. If resources contain geometry, the geometry shall be returned as a GeoJSON <code>Geometry</code> object embedded in the resource. The media type <code>application/json</code> must be supported. The media type <code>application/geo+json</code> should not be supported while the resource does not comply to the GeoJSON specification, i.e. the response does not return a feature or feature collection.
+A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the responses in OpenAPI definitions are available [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
+In case a collection of resources is returned, the name of the array containing the resources should be the plural of the resource name.
+
+<div class="rule" id="api-geo-4">
+  <p class="rulelab"><strong>API-GEO-4</strong>: Embed GeoJSON <code>Geometry</code> object as part of the JSON resource</p>
+  <p>When a JSON (<code>application/json</code>) response contains a geometry, represent it in the same way as the <code>Geometry</code> object of GeoJSON.</p>
+
+  Example: resource containing geometry
+  <pre>
+  {
+    "identificatie": "0308100000022041",
+    "naam": "Paleis Soestdijk",
+    "geometrie":  {
+      "type": "Point",
+      "coordinates": [5.2795,52.1933]
+    },
+    ...,
+    "_links": {
+      {
+        "self": ""
+      }
+    }
+  }</pre>
+
+  Example: collection of resources containing geometry
+  <pre>
+  {
+    "&lt;plural of resource name&gt;": [
+    {
+      "identificatie": "0308100000022041",
+      "naam": "Paleis Soestdijk",
+      "geometrie":  {
+        "type": "Point",
+        "coordinates": [5.2795,52.1933]
+      }
+      ...
+      "_links": {
+        {
+          "self": ""
+        }
+      }
+    } ],
+    "_links": {
+      {
+        "self": ""
+      },
+      {
+        "next": ""
+      }
+    }
+  }</pre>
+  <p>
+  Note that:
+  
+  - The resource and resource collection may be HAL resources and therefor may contain a _links object, that shall contain a self link and in case of a collection may contain navigation links.
+  </p>
+  <h4 class="rulelab">How to test</h4>
+  <p>
+  Test case 1:
+  </p>
+  <ul>
+    <li>Request a single resource that contains geometry of GeoJSON <code>Geometry</code> object type: <code>Point</code>, <code>MultiPoint</code>, <code>LineString</code>, <code>MultiLineString</code>, <code>Polygon</code> or <code>MultiPolygon</code> and with response media type <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
+    <li>Validate that the returned document contains a property that complies to one of the GeoJSON <code>Geometry</code> objects mentioned above and contains:</li>
+    <ul>
+      <li>a property <code>type</code> containing the name of one of the GeoJSON <code>Geometry</code> object types mentioned above, and</li>
+      <li>a property <code>coordinates</code> containing an array with the coordinates. Depending on the type of geometry object, the content of the array differs.</li>
+    </ul>
+  </ul>
+  <p>
+  Test case 2:
+  </p>
+  <ul>
+    <li>Request a collection of resources that contain geometry of GeoJSON <code>Geometry</code> object type: <code>Point</code>, <code>MultiPoint</code>, <code>LineString</code>, <code>MultiLineString</code>, <code>Polygon</code> or <code>MultiPolygon</code> and with response media type <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
+    <li>Validate that the returned document contains a property that complies to one of the GeoJSON <code>Geometry</code> objects mentioned above and contains:</li>
+    <ul>
+      <li>a property <code>type</code> containing the name of one of the GeoJSON <code>Geometry</code> object types mentioned above, and</li>
+      <li>a property <code>coordinates</code> containing an array with the coordinates. Depending on the type of geometry object, the content of the array differs.</li>
+    </ul>
+  </ul>
+  <p>
+  Test case 3:
+  </p>
+  <ul>
+    <li>Request a single resource that contains geometry of GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code> and with response media type <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
+    <li>Validate that the returned document contains a property that complies to the GeoJSON <code>Geometry</code> object metntioned above and contains: </li>
+    <ul>
+      <li>a property <code>type</code> containing the name of the GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code>, and</li>
+      <li>a property <code>geometries</code> containing an array of GeoJSON <code>Geometry</code> objects.</li>
+    </ul>
+  </ul>
+  <p>
+  Test case 4:
+  </p>
+  <ul>
+    <li>Request a collection of resources that contain geometry of GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code> and with response media type <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Validate that a response with status code 200 is returned.</li>
+    <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
+    <li>Validate that the returned document is a JSON document.</li> 
+    <li>Validate that the returned document contains a property that complies to the GeoJSON <code>Geometry</code> object metntioned above and contains: </li>
+    <ul>
+      <li>a property <code>type</code> containing the name of the GeoJSON <code>Geometry</code> object type: <code>GeometryCollection</code>, and</li>
+      <li>a property <code>geometries</code> containing an array of GeoJSON <code>Geometry</code> objects.</li>
+    </ul>
+  </ul>
+</div>
+
+TO DO
+Moet hier ook iets worden gezegd over de naam van de property die de GeoJSON bevat? Als we hier kiezen voor geometry als naam (zoals ook voorgeschreven in OGC API Features, dan ontstaan er verschillen in de naamgeving van attributen in de resources. 
+
+
+
+
+

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -180,7 +180,7 @@ In case a REST API shall comply to the OGC API Features specification, e.g. for 
   Test case 2:
   </p>
   <ul>
-    <li>Request a collection of resources that include feature content (i.e. coordinates) with response media type <code>application/geo+json</code> in the <code>Accept</code> header.</li>
+    <li>Request a collection of resources that includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> in the <code>Accept</code> header.</li>
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/geo+json</code></li> 
     <li>Validate that the returned document is a GeoJSON FeatureCollection document.</li> 
@@ -198,7 +198,7 @@ In case a REST API shall comply to the OGC API Features specification, e.g. for 
   Test case 4:
   </p>
   <ul>
-    <li>Request a collection of resources that do not includes feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
+    <li>Request a collection of resources that do not include feature content (i.e. coordinates) with response media type <code>application/geo+json</code> or <code>application/json</code> in the <code>Accept</code> header.</li>
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Validate that <code>Content-Type</code> header contains <code>application/json</code></li> 
     <li>Validate that the returned document is a JSON document.</li> 

--- a/API-strategie-modulen/API-strategie-mod-geo/request-response.md
+++ b/API-strategie-modulen/API-strategie-mod-geo/request-response.md
@@ -48,24 +48,16 @@ A simple spatial filter can be supplied as a bounding box. This is a common way 
   </p>
   <h4 class="rulelab">How to test</h4>
   <ul>
-    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> query parameter and <code>bbox-crs</code> heaeder containing a CRS supported by the provider. If the provider supports CRS84 than the <code>bbox-crs</code> header may be omitted.</li>
+    <li>Issue an HTTP GET request to the API, including the <code>bbox</code> query parameter and using <a href="https://docs.geostandaarden.nl/api/API-strategie-modulen/API-strategie-mod-geo/#crs-negotiation">CRS Negotiation</a>.</li>
     <li>Validate that a response with status code 200 is returned.</li>
     <li>Verify that only features that have a spatial geometry that intersects the bounding box are returned as part of the result set.</li>
   </ul>
 </div>
 
-TO DO 
-Bovenstaande voorbeeld is redundant met het voorbeeld bij API-GEO-10. Het lijkt me goed om hier het voorbeeld van bbox te gebruiken en bij API-GEO-10 een ander voorbeeld, of vanuit API-GEO-10 te verwijzen naar dit voorbeeld of andersom.
-
 <aside class="note">
 Spatial filtering is an extensive topic. There are use cases for geospatial operators like <code>intersects</code> or <code>within</code>. Geospatial filters can be large and complex, which sometimes causes problems since <code>GET</code> may not have a payload (although supported by some clients). 
 
 More complex spatial filtering is not addressed in this module. A new API Design Rules module on filtering will address spatial as well as non-spatial filtering. [[ogcapi-features-3]] will provide input for this.
-
-TO DO 
-Moet hier een requirement worden opgenomen, dat als er met geometrie gezocht wordt, tenminste GeoJSON <code>Geometry</code> objecten ondersteund moeten worden? Of als de geometrie niet in GeoJSON past (curves etc.) dat dan WKT en WKB ondersteund moeten worden?
-
-Onderstaande hoort hier m.i. niet, maar dat is volgens mij issue #496.
 
 However, until the filtering module is written, the geospatial module retains rule API-GEO-3 about dealing with results of a global spatial query. This rule may be moved to the filtering module at a later stage.
 </aside>
@@ -268,7 +260,7 @@ In case a collection of resources is returned, the name of the array containing 
   <p>
   Note that:
   
-  - The resource and resource collection may be HAL resources and therefor may contain a _links object, that shall contain a self link and in case of a collection may contain navigation links.
+  - The resource and resource collection may be [[HAL]] resources and therefor may contain a _links object. The _links object should contain a self link and in case of a collection also navigation links (e.g. first, next prev, last).
   </p>
   <h4 class="rulelab">How to test</h4>
   <p>
@@ -328,11 +320,6 @@ In case a collection of resources is returned, the name of the array containing 
     </ul>
   </ul>
 </div>
-
-TO DO
-Moet hier ook iets worden gezegd over de naam van de property die de GeoJSON bevat? Als we hier kiezen voor geometry als naam (zoals ook voorgeschreven in OGC API Features, dan ontstaan er verschillen in de naamgeving van attributen in de resources. 
-
-
 
 
 


### PR DESCRIPTION
mbt API-GEO-1: Hoe verhoudt dit zich tot andere media types? Lever je voor een feature (collection) dan ook nog een HAL (of andere) response?
[MSR] het punt bij API-GEO-1 is, dat er wordt gesteld dat als een resource geometrie bevat deze als een Feature of FeatureCollection geretourneerd moet worden. Dit geldt wel voor GIS applicaties, maar bv. niet voor administratieve systemen. Het resultaat kan dus verschillen bij een OGC API Features compliant API of een API die dat niet is. Bij de laatste kan een HAL resource geretourneerd worden, maar het hoeft niet, dat staat los van geometrie.

NB:
Het voorbeeld bij API-GEO-4 geeft een concreet voorbeeld hoe de response er bij een administratieve API uit ziet. Om het verschil goed duidelijk te maken met een OGC API Features API, heb ik hetzelfde voorbeeld conform OGC API features toegevoegd. De property 'naam' is hier een property van een object en deze hoort dan onder het properties object in de response.

mbt API-GEO-1: Wat doe je met alle non-geometry attributen, voeg je die allemaal toe als feature properties? Of enkel een subset?
[MSR] Voorbeeld volgens OGC API features toegevoegd en een note toegevoegd, dat dit afhankelijk is van de Geímplementeerde filter functionaliteit.

mbt API-GEO-1: De beschrijving heeft het enkel over de response, waarom is dit dan niet onderdeel van ""2.3 Result (response)""?
[MSR] Deel verplaatst naar response. Let op: API rules moeten nog worden hernummerd.

mbt API-GEO-1: Onduidelijk of dit gaat over het toepassen van het Feature(Collection) model (heel document) of om embedded Geometry(Collection) objecten (in een document van een ander mediatype).
[MSR] done 

mbt API-GEO-1: ""preferebaly use"" waarom zwak geformuleerd?
[MSR] done

mbt API-GEO-1: Relatie met andere API mediatypes onduidelijk. Hoe kom je aan de resource location? application/geo+json biedt geen api navigatie controls
[MSR] 
Als er aan OGC API Features voldaan moet worden: 
In OGC API Features en GeoJSON beschrijvingen staan voorbeelden om links te retourneren in een feature of feature collection, dus ook de mogelijkheid om navigatielinks toe te voegen.
Als er niet aan OGC API Features voldaan moet worden heeft de provider de keuze om een HAL resource te retourneren met navigatielinks en waarin evt. geometry in GeoJSON wordt teruggegeven.
Eigenlijk is navigatie hier niet zo relevant omdat dat een ander algemeen aspect is dat niet in een geo module uitgelegd moet worden, maar ik heb de opmerkingen toch verwerkt in de voorbeelden en een note toegevoegd.

mbt API-GEO-1: OGC api features requirements class 8.3 geeft aan dat bij meerdere features een featurecollection gebruikt wordt. Denk handig om dit in ""how to test"" op te nemen.
[MSR] done
