### PR TITLE
Geo module editorial changes

### DIFF
--- a/API-strategie-modules/geospatial/abstract.md
+++ b/API-strategie-modules/geospatial/abstract.md
@@ -1,4 +1,4 @@
 The API strategy consists of a *core* &mdash; a generic set of rules for all government APIs &mdash; and various *modules* that only pertain to a specific application. See [API Strategie](https://www.geonovum.nl/node/250#APIStrategie) for a list of all parts of the API Strategy.
 
 <!-- below: specific part for this module only -->
-This document describes the Geospatial module, containing rules for geospatial content and functions in APIs.
+This document describes the *Geospatial module*, containing rules for geospatial content and functions in APIs.

--- a/API-strategie-modules/geospatial/appendix.md
+++ b/API-strategie-modules/geospatial/appendix.md
@@ -1,9 +1,9 @@
 # Appendix - deprecated rules
-This appendix contains some of the rules that were described in the [first version](https://docs.geostandaarden.nl/api/API-Strategie-ext/#geospatial) of the "Geospatial Extension", which was never ratified. Only those rules that are still relevant in some situations or do not have a good replacement in the current Geospatial model are retained here. They are shown here only as information. 
+This appendix contains some of the rules that were described in the [first version](https://docs.geostandaarden.nl/api/API-Strategie-ext/#geospatial) of the "Geospatial Extension", which was never officially adopted as a standard. Only those rules that are still relevant in some situations or do not have a good replacement in the current Geospatial model are retained here. They are shown here only as information. 
 
 ## POST endpoint for geospatial queries
 
-<aside class="note">Two rules related to using a POST endpoint for geospatial queries were deprecated because it is expected that a new API Design Rules module "Filtering" will address the issue of using POST for geospatial queries. Until then, the old rules may still be of use.
+<aside class="note">Two rules related to using a POST endpoint for geospatial queries were deprecated because it is expected that a new API Design Rules module "Filtering" will address the issue of using POST for queries. Until then, the old rules may still be of use.
 
 What follows is the original description of the rules in the old Geospatial Extension. 
 </aside>
@@ -46,7 +46,7 @@ The `POST` endpoint is preferably set up as a generic query endpoint to support 
 
 ## Old CRS negotiation method
 
-<aside class="note">An older method of specifying CRS in the headers of requests was part of the first version of the "Geospatial Extension" which was never ratified. APIs that already support this old header method can add support for the current parameter method (see [CRS negotiation](./crs.md#crs-negotiation)) while still supporting the header method for a certain period. Supporting both the new method (using parameters) and the old (using headers) is trivial. 
+<aside class="note">An older method of specifying CRS in the headers of requests was part of the first version of the "Geospatial Extension" which was never officially adopted as a standard. APIs that already support this old header method can add support for the current parameter method (see <a href="#crs-negotiation">CRS negotiation</a>) while still supporting the header method for a certain period. Supporting both the new method (using parameters) and the old (using headers) is trivial. 
 
 If a client specifies CRS using a parameter AND in the header, the parameter takes precedence and the CRS in the header is ignored.
 

--- a/API-strategie-modules/geospatial/crs.md
+++ b/API-strategie-modules/geospatial/crs.md
@@ -13,8 +13,8 @@ For a detailed description of CRSs see [[hr-crs]].
 
 A client shall be able to determine a list of CRSs supported by an API.
 
-<div class="rule" id="api-geo-5">
-  <p class="rulelab"><strong>API-GEO-5</strong>: Provide a list of all CRSs that are supported by the API</p>
+<div class="rule" id="api-geo-7">
+  <p class="rulelab"><strong>API-GEO-7</strong>: Provide a list of all CRSs that are supported by the API</p>
   <p>If a REST API shall comply to the OGC API Features specification then the API must provide an endpoint to determine a list of supported CRSs.</p>
   <pre>
   // GET /api/v1/collections:</pre>
@@ -49,10 +49,10 @@ If a feature collection supports additional CRSs compared to the global CRS list
 
 If a feature collection supports a different set of CRSs than the set defined in the global CRS list, then a reference to the global CRS list is omitted and only the URIs of the supported CRSs are added to the CRS list in the `crs` property of the feature collection.
 
-For clients, it may be helpful to know the CRS identifier that may be used to retrieve features from that collection without the need to apply a CRS transformation.
+For clients, it may be helpful to know the CRS identifier that may be used to retrieve features from that collection without the need to apply a CRS transformation. If all features in a feature collection are stored using a particular CRS, the property `storageCRS` shall be used to specify this CRS, in accordance with [OGC API Features - part 2 - 6.2.2 Storage CRS](https://docs.ogc.org/is/18-058/18-058.html#_storage_crs). The value of this property shall be one of the CRSs supported by the API and advertised in the CRS list as stated in requirement 4 of [OGC API Features - part 2 - 6.2.2 Storage CRS](https://docs.ogc.org/is/18-058/18-058.html#_storage_crs). If relevant, the epoch should also be specified, using the `storageCRSCoordinateEpoch` property. For an explanation of the use of epochs with CRS, see the CRS Guidelines [[hr-crs]]. 
 
-<div class="rule" id="api-geo-6">
-  <p class="rulelab"><strong>API-GEO-6</strong>: Make known in which CRS the geospatial data is stored by specifying the property <code>storageCrs</code> in the collection object. </p>
+<div class="rule" id="api-geo-8">
+  <p class="rulelab"><strong>API-GEO-8</strong>: Make known in which CRS the geospatial data is stored by specifying the property <code>storageCrs</code> in the collection object. </p>
   <p>The value of this property shall be one of the CRSs the API supports.</p> 
   <h4 class="rulelab">How to test</h4>
   <ul>
@@ -61,8 +61,6 @@ For clients, it may be helpful to know the CRS identifier that may be used to re
     <li>Validate that the value of the <code>storageCRS</code> property is one of the URIs from the list of supported CRSs.</li>
   </ul>
 </div>
-
-If all features in a feature collection are stored using a particular CRS, the property `storageCRS` shall be used to specify this CRS, in accordance with [OGC API Features - part 2 - 6.2.2 Storage CRS](https://docs.ogc.org/is/18-058/18-058.html#_storage_crs). The value of this property shall be one of the CRSs supported by the API and advertised in the CRS list as stated in requirement 4 of [OGC API Features - part 2 - 6.2.2 Storage CRS](https://docs.ogc.org/is/18-058/18-058.html#_storage_crs). If relevant, the epoch should also be specified, using the `storageCRSCoordinateEpoch` property. For an explanation of the use of epochs with CRS, see the CRS Guidelines [[hr-crs]]. 
 
 ## CRS negotiation
 
@@ -76,8 +74,8 @@ Since most client-side mapping libraries use WGS 84 longitude-latitude (CRS84), 
 
 The *default* CRS, i.e. the CRS which is assumed when not specified by either the API or the client, is CRS84, in line with GeoJSON and OGC API Features. 
 
-<div class="rule" id="api-geo-7">
-  <p class="rulelab"><strong>API-GEO-7</strong>: Use <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">CRS84</a> as the default coordinate reference system (CRS). Support CRS84 in line with OGC API Features <a href="http://docs.ogc.org/is/17-069r3/17-069r3.html#_coordinate_reference_systems">Requirement 10</a>. </p>
+<div class="rule" id="api-geo-9">
+  <p class="rulelab"><strong>API-GEO-9</strong>: Use <a href="http://www.opengis.net/def/crs/OGC/1.3/CRS84">CRS84</a> as the default coordinate reference system (CRS). Support CRS84 in line with OGC API Features <a href="http://docs.ogc.org/is/17-069r3/17-069r3.html#_coordinate_reference_systems">Requirement 10</a>. </p>
   <p>The implication of this is, that if no CRS is explicitly included in the request, CRS84 is assumed. This rule also applies if the request uses POST.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
@@ -89,8 +87,8 @@ The *default* CRS, i.e. the CRS which is assumed when not specified by either th
 
 In addition, support for ETRS89 and/or RD is required. 
 
-<div class="rule" id="api-geo-8">
-  <p class="rulelab"><strong>API-GEO-8</strong>: Use ETRS89 and/or RD when required, as these are the preferred coordinate reference systems (CRS) for Dutch geospatial data. Follow the Dutch Guideline for the use of CRSs [[hr-crs]].</p>
+<div class="rule" id="api-geo-10">
+  <p class="rulelab"><strong>API-GEO-10</strong>: Use ETRS89 and/or RD when required, as these are the preferred coordinate reference systems (CRS) for Dutch geospatial data. Follow the Dutch Guideline for the use of CRSs [[hr-crs]].</p>
   <p>General usage of the European ETRS89 coordinate reference system (CRS) or RD/NAP is preferred, but is not the default CRS. Hence, one of these CRSs has to be explicitly included in each request when one of these CRSs is desired in the response or used in a request.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
@@ -114,10 +112,10 @@ The guiding principles for CRS support:
 - Use an ensemble member CRS (instead of an ensemble CRS) for exchanging geometry, when known.
 - Use an ensemble member CRS (instead of an ensemble CRS) as output of coordinate transformation, when known.
 - APIs shall support and advertise both ensemble CRSs and ensemble member CRSs if geometry is exchanged and the CRS for the geometry is an ensemble member CRS.
-- under certain conditions WGS 84 can be made equal to e.g. ETRS89, this is called a nultransformation, see [[hr-crs]]. If a nultransformation is used to realize WGS 84, then the CRS (e.g. ETRS89) that is used to realize WGS 84 shall be supported and advertised by an API.
+- Under certain conditions WGS 84 can be made equal to e.g. ETRS89, this is called a nultransformation, see [[hr-crs]]. If a nultransformation is used to realize WGS 84, then the CRS (e.g. ETRS89) that is used to realize WGS 84 shall be supported and advertised by an API.
 
-<div class="rule" id="api-geo-9">
-  <p class="rulelab"><strong>API-GEO-9</strong>: When the API provides data in an ensemble CRS like WGS 84 or ETRS89 while it is known to what ensemble member CRS the data actually refers, this ensemble member should also be one of the CRSs supported by the API and advertised in the CRS list. E.g. when 2D data is transformed from RD with RDNAPTRANS not only EPSG:4258 should be supported but also EPSG::9067.</p>
+<div class="rule" id="api-geo-11">
+  <p class="rulelab"><strong>API-GEO-11</strong>: When the API provides data in an ensemble CRS like WGS 84 or ETRS89 while it is known to what ensemble member CRS the data actually refers, this ensemble member should also be one of the CRSs supported by the API and advertised in the CRS list. E.g. when 2D data is transformed from RD with RDNAPTRANS not only EPSG:4258 should be supported but also EPSG:9067.</p>
   <h4 class="rulelab">How to test</h4>
   <ul>
     <li>Issue an HTTP GET request to the <code>/collections</code> endpoint.</li>
@@ -129,12 +127,12 @@ The guiding principles for CRS support:
 
 The CRS can be specified for request and response individually using parameters or headers.
 
-<div class="rule" id="api-geo-10">
-  <p class="rulelab"><strong>API-GEO-10</strong>: Support passing the coordinate reference system (CRS) of the geometry in the request as a query parameter</p>
+<div class="rule" id="api-geo-12">
+  <p class="rulelab"><strong>API-GEO-12</strong>: Support passing the coordinate reference system (CRS) of the geometry in the request as a query parameter</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_parameter_bbox_crs">OGC API Features part 2 <code>bbox-crs</code> parameter</a> in conformance to the standard.
   </p>
-  <p>If a bounding box or geospatial filter is sent to the server without these parameters, the default CRS, CRS84, is assumed as specified in <a href="#api-geo-7">API-GEO-7</a>.</p>
-  <p>If an invalid value, i.e. a CRS which is not in the list of supported CRSs, is given for one of these parameters, the server responds with an HTTP status code `400`.</p>
+  <p>If a bounding box or geospatial filter is sent to the server without these parameters, the default CRS, CRS84, is assumed as specified in <a href="#api-geo-9">API-GEO-9</a>.</p>
+  <p>If an invalid value, i.e. a CRS which is not in the list of supported CRSs, is given for one of these parameters, the server responds with an HTTP status code <code>400</code>.</p>
   <p>Additionally, if other types of geospatial filters are supported in the API besides <code>bbox</code>: </p>
   <p>Support the <a href="http://docs.ogc.org/DRAFTS/19-079r1.html#filter-filter-crs">OGC API Features part 3 <code>filter-crs</code> parameter</a> in conformance to the standard.
   </p>
@@ -149,10 +147,10 @@ The CRS can be specified for request and response individually using parameters 
 
 In an API that supports the creation and/or updating of items, POST, PUT or PATCH requests with geospatial content in the body may be sent by a client to the server. In that case, it is necessary to indicate the CRS used, unless CRS84, the default CRS, is used.
 
-<div class="rule" id="api-geo-11">
-  <p class="rulelab"><strong>API-GEO-11</strong>: When HTTP POST, PUT and/or PATCH requests are supported, pass the coordinate reference system (CRS) of geometry in the request body as a header</p>
+<div class="rule" id="api-geo-13">
+  <p class="rulelab"><strong>API-GEO-13</strong>: When HTTP POST, PUT and/or PATCH requests are supported, pass the coordinate reference system (CRS) of geometry in the request body as a header</p>
   <p>Support the <a href="http://docs.ogc.org/DRAFTS/20-002.html#feature-crs">OGC API Features part 4 <code>Content-Crs</code> header</a> in conformance to the standard.</p>
-  <p>Alternatively, if the feature representation supports expressing CRS information for each feature / geometry, the information can also be included in the feature representation. If no CRS is asserted, the default CRS, CRS84, is assumed, as stated in <a href="#api-geo-7">API-GEO-7</a>.<p>
+  <p>Alternatively, if the feature representation supports expressing CRS information for each feature / geometry, the information can also be included in the feature representation. If no CRS is asserted, the default CRS, CRS84, is assumed, as stated in <a href="#api-geo-9">API-GEO-9</a>.<p>
   <h4 class="rulelab">How to test</h4>
   <p>In a request (i.e. when creating or updating an item on the server):</p>
   <uL>
@@ -162,8 +160,8 @@ In an API that supports the creation and/or updating of items, POST, PUT or PATC
   <p>Repeat with a similar test voor PUT and/or PATCH if the server supports these.</p>
 </div>
 
-<div class="rule" id="api-geo-12">
-  <p class="rulelab"><strong>API-GEO-12</strong>: Support passing the desired coordinate reference system (CRS) of the geometry in the response as a query parameter</p>
+<div class="rule" id="api-geo-14">
+  <p class="rulelab"><strong>API-GEO-14</strong>: Support passing the desired coordinate reference system (CRS) of the geometry in the response as a query parameter</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_parameter_crs">OGC API Features part 2 <code>crs</code> parameter</a> in conformance to the standard.
   </p>
   <h4 class="rulelab">How to test</h4>
@@ -173,8 +171,8 @@ In an API that supports the creation and/or updating of items, POST, PUT or PATC
   </ul>
 </div>
 
-<div class="rule" id="api-geo-13">
-  <p class="rulelab"><strong>API-GEO-13</strong>: Assert the coordinate reference system (CRS) used in the response using a header</p>
+<div class="rule" id="api-geo-15">
+  <p class="rulelab"><strong>API-GEO-15</strong>: Assert the coordinate reference system (CRS) used in the response using a header</p>
   <p>Support the <a href="http://docs.opengeospatial.org/is/18-058/18-058.html#_coordinate_reference_system_information_independent_of_the_feature_encoding">OGC API Features part 2 <code>Content-Crs</code> header</a> in conformance to the standard.
   </p>
   <h4 class="rulelab">How to test</h4>
@@ -213,7 +211,7 @@ Below is a list of the most commonly used CRSs in the Netherlands:
 | WGS 84 / Pseudo-Mercator | 2D | Global | http://www.opengis.net/def/crs/EPSG/9.9.1/3857 |
 
 For a more extensive overview of CRSs see: https://docs.geostandaarden.nl/crs/crs/#bijlage-a-crs-overzicht-tabel.
-Note that The URI of each CRS contains a version number and that new versions may be released in future.
+Note that the URI of each CRS contains a version number and that new versions may be released in future.
 Before using a URI verify if newer versions are available and use the latest version.
 
 <aside class="note" title="CRS support and GeoJSON">

--- a/API-strategie-modules/geospatial/index.html
+++ b/API-strategie-modules/geospatial/index.html
@@ -31,7 +31,7 @@
   <!-- HTML-Body ================================================================================ -->
   <body>
     <section id="abstract" data-format="markdown" data-include="abstract.md"></section>
-    <section id="sotd">In dit document zijn wijzigingen naar aanleiding van een deel van de consultatiereacties doorgevoerd. Nog niet alle consultatiereacties zijn verwerkt. </section>
+    <section id="sotd"></section>
     <!-- vanaf hier per hoofdstuk een sectie of een div in het document ======================== -->
     <!-- Secties komen in de inhoudsopgave div's niet ========================================== -->
     <!-- Secties hebben verplicht <h2> tags, div's niet ======================================== -->

--- a/API-strategie-modules/geospatial/introduction.md
+++ b/API-strategie-modules/geospatial/introduction.md
@@ -15,5 +15,4 @@ Geospatial data is 'special' data in the sense that it typically indicates the l
 
 The Geospatial Module provides rules for the structuring of geospatial payloads and for functions in APIs to handle geospatial data.
 
-
-In the geospatial module the abbreviation RD is used. RD refers to the "Stelsel van de Rijksdriehoeksmeting", this is the equivalent of EPSG code 28992 and EPSG name Amersfoort / RD New.
+<aside class="note">In the geospatial module the abbreviation RD is used. RD refers to the "Stelsel van de Rijksdriehoeksmeting", this is the equivalent of EPSG code 28992 and EPSG name Amersfoort / RD New.</aside>

--- a/API-strategie-modules/geospatial/request-response.md
+++ b/API-strategie-modules/geospatial/request-response.md
@@ -7,6 +7,10 @@ Providing requested resources is the essence of any API. This also applies to RE
 
 When requesting information, for example about cadastral parcels, users do not necessarily require the geometry, even if they used a spatial filter. A name or parcel ID may be sufficient.
 
+<aside class="note">
+The Geospatial Module is focused on JSON-based encoding of data. However, consider also supporting <code>text/html</code>, as recommended in OGC API Features [[ogcapi-features-1]]. Sharing data on the Web should include publication in HTML, as this allows discovery of the data through common search engines as well as viewing the data directly in a browser.
+</aside>
+
 ## GeoJSON
 
 [[rfc7946]] describes the GeoJSON format, including a convention for describing 2D geometric objects in CRS84. In the Geospatial module of the API strategy we adopt the GeoJSON conventions for describing geometry objects. The convention is extended to allow alternative projections.
@@ -66,8 +70,8 @@ Sample response:
 
 A simple spatial filter can be supplied as a bounding box. This is a common way of filtering spatial data and can be supplied as a parameter. We adopt the OGC API Features [[ogcapi-features-1]] bounding box parameter:
 
-<div class="rule" id="api-geo-2">
-  <p class="rulelab"><strong>API-GEO-2</strong>: Supply a simple spatial filter as a bounding box parameter</p>
+<div class="rule" id="api-geo-1">
+  <p class="rulelab"><strong>API-GEO-1</strong>: Supply a simple spatial filter as a bounding box parameter</p>
   <p>Support the <a href="https://docs.ogc.org/is/17-069r4/17-069r4.html#_parameter_bbox">OGC API Features part 1 <code>bbox</code> query parameter</a> in conformance to the standard.</p> 
   <pre>
     GET /api/v1/buildings?bbox=5.4,52.1,5.5,53.2</pre>
@@ -96,11 +100,11 @@ Spatial filtering is an extensive topic. There are use cases for geospatial oper
 
 More complex spatial filtering is not addressed in this module. A new API Design Rules module on filtering will address spatial as well as non-spatial filtering. [[ogcapi-features-3]] will provide input for this.
 
-However, until the filtering module is written, the geospatial module retains rule API-GEO-3 about dealing with results of a global spatial query. This rule may be moved to the filtering module at a later stage.
+However, until the filtering module is written, the geospatial module retains rule API-GEO-2 about dealing with results of a global spatial query. This rule may be moved to the filtering module at a later stage.
 </aside>
 
-<div class="rule" id="api-geo-3">
-  <p class="rulelab"><strong>API-GEO-3</strong>: Place results of a global spatial query in the relevant geometric context</p>
+<div class="rule" id="api-geo-2">
+  <p class="rulelab"><strong>API-GEO-2</strong>: Place results of a global spatial query in the relevant geometric context</p>
   <p>In case of a global query <code>/api/v1/_search</code>, results should be placed in the relevant geometric context, because results from different <a href="https://publicatie.centrumvoorstandaarden.nl/api/adr/#resources">collections</a>, i.e. different sets of resources of the same type, are retrieved. Express the name of the collection to which the results belong in the singular form using the property <code>type</code>. For example:</p>
   <pre>
   // POST /api/v1/_search:
@@ -137,11 +141,11 @@ However, until the filtering module is written, the geospatial module retains ru
   </ul>
 </div>
 
-In case a REST API shall comply to the OGC API Features specification for creating, replacing, updating and deleting a resource, the following applies.
+In case a REST API shall comply to the OGC API Features specification for creating, updating and deleting a resource, the following applies.
 
-<div class="rule" id="api-geo-1">
-  <p class="rulelab"><strong>API-GEO-4</strong>: Support GeoJSON for geospatial APIs</p>
-  <p>For representing geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in <a href="http://docs.ogc.org/DRAFTS/20-002.html">OGC API Features part 4</a>, but note that this standard is still in development.</p>
+<div class="rule" id="api-geo-3">
+  <p class="rulelab"><strong>API-GEO-3</strong>: Support GeoJSON in geospatial API requests</p>
+  <p>For representing geometric information in an API request, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in <a href="http://docs.ogc.org/DRAFTS/20-002.html">OGC API Features part 4</a>, but note that this standard is still in development.</p>
   Example: POST feature
   <pre>
   POST /collections/gebouwen/items   HTTP/1.1
@@ -187,11 +191,11 @@ In case a REST API shall comply to the OGC API Features specification for creati
 </div>
 
 In case a REST API does not have to comply to the OGC API Features specification, e.g. for usage in administrative applications, the REST API shall use the JSON data format. If a resource contains geometry, that geometry shall be embedded as a GeoJSON <code>Geometry</code> object within the resource. The media type <code>application/json</code> must be supported. This may also apply to other media types <code>application/*+json</code>, however this depends on the media type specification. If the media type specification prescribes that resource information must be embedded in a JSON structure defined in the media specification, then the media type should not be supported while it is impossible to comply to that specification with the method described below. The media type <code>application/geo+json</code> should not be supported while the resource does not comply to the GeoJSON specification, i.e. the request resource does not embed a feature or feature collection.
-A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the requests in OpenAPI definitions are available [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
+A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the requests in OpenAPI definitions is available: [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
 In case a collection of resources is embedded in the request resource, the name of the array containing the resources should be the plural of the resource name.
 
 <div class="rule" id="api-geo-4">
-  <p class="rulelab"><strong>API-GEO-4</strong>: Embed GeoJSON <code>Geometry</code> object as part of the JSON resource</p>
+  <p class="rulelab"><strong>API-GEO-4</strong>: Embed GeoJSON <code>Geometry</code> object as part of the JSON resource in API requests</p>
   <p>When a JSON (<code>application/json</code>) request contains a geometry, represent it in the same way as the <code>Geometry</code> object of GeoJSON.</p>
   Example: POST resource containing geometry
   <pre>
@@ -235,9 +239,9 @@ In case a collection of resources is embedded in the request resource, the name 
 
 In case a REST API shall comply to the OGC API Features specification, e.g. for usage in GIS applications, the following applies.
 
-<div class="rule" id="api-geo-1">
-  <p class="rulelab"><strong>API-GEO-1</strong>: Support GeoJSON for geospatial APIs</p>
-  <p>For representing 2D geometric information in an API, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. </p>
+<div class="rule" id="api-geo-5">
+  <p class="rulelab"><strong>API-GEO-5</strong>: Support GeoJSON in geospatial API responses</p>
+  <p>For representing 2D geometric information in an API response, use the convention for describing geometry as defined in the GeoJSON format [[rfc7946]]. Support GeoJSON as described in OGC API Features <a href="https://docs.ogc.org/is/17-069r3/17-069r3.html#_requirements_class_geojson">Requirements class 8.3</a> [[ogcapi-features-1]]. </p>
   Example: feature
   <pre>
   Request:
@@ -309,7 +313,7 @@ In case a REST API shall comply to the OGC API Features specification, e.g. for 
   Note that:
   
   - The resources' properties (e.g. <code>naam</code>) are passed in the properties object. Depending on the implemented filter capabilities the properties object may contain all or a selection of the resources' properties.
-  - The OGC API Fearures specification provides the possibility to add an array of links to a feature and feature collection, which may contain a self link and in case of a feature collection may contain navigation links.
+  - The OGC API Features specification provides the possibility to add an array of links to a feature and feature collection, which may contain a self link and in case of a feature collection may contain navigation links.
   </p>
   <h4 class="rulelab">How to test</h4>
   <p>
@@ -351,11 +355,11 @@ In case a REST API shall comply to the OGC API Features specification, e.g. for 
 </div>
 
 In case a REST API does not have to comply to the OGC API Features specification, e.g. for usage in administrative applications, the REST API shall use the JSON data format. If resources contain geometry, the geometry shall be returned as a GeoJSON <code>Geometry</code> object embedded in the resource. The media type <code>application/json</code>  must be supported. This may also apply to other media types <code>application/\*+json</code>, however this depends on the media type specification. If the media type specification prescribes that resource information must be embedded in a JSON structure defined in the media type specification, then the media type should not be supported while it is impossible to comply to that specification with the method described below. The media type <code>application/geo+json</code> should not be supported while the resource does not comply to the GeoJSON specification, i.e. the response does not return a feature or feature collection.
-A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the responses in OpenAPI definitions are available [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
+A template for the definition of the schemas for the GeoJSON <code>Geometry</code> object in the responses in OpenAPI definitions is available: [geometryGeoJSON.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml).
 In case a collection of resources is returned, the name of the array containing the resources should be the plural of the resource name.
 
-<div class="rule" id="api-geo-4">
-  <p class="rulelab"><strong>API-GEO-4</strong>: Embed GeoJSON <code>Geometry</code> object as part of the JSON resource</p>
+<div class="rule" id="api-geo-6">
+  <p class="rulelab"><strong>API-GEO-6</strong>: Embed GeoJSON <code>Geometry</code> object as part of the JSON resource in API responses</p>
   <p>When a JSON (<code>application/json</code>) response contains a geometry, represent it in the same way as the <code>Geometry</code> object of GeoJSON.</p>
 
   Example: resource containing geometry
@@ -447,7 +451,7 @@ In case a collection of resources is returned, the name of the array containing 
   <p>
   Note that:
   
-  - The resource and resource collection may be [[HAL]] resources and therefore may contain a _links object. The _links object should contain a self link and in case of a collection also navigation links (e.g. first, next prev, last). In such cases the <code>application/hal+json</code> media type may be used.
+  - The resource and resource collection may be [[HAL]] resources and therefore may contain a `_links` object. The `_links` object should contain a self link and in case of a collection also navigation links (e.g. first, next prev, last). In such cases the <code>application/hal+json</code> media type may be used.
   </p>
   <h4 class="rulelab">How to test</h4>
   <p>


### PR DESCRIPTION
Dit zijn redactionele wijzigingen voor de geomodule. 
- Opnieuw PR aangemaakt voor de `master` branch, omdat de `Development-modulaire-opbouw` branch vorige week is gemerged met `master`.
- Rules hernummerd
- Kleine redactionele edits
- 1 stukje tekst over storageCRS een paar regels omhoog verplaatst, voor de flow van de tekst.

@strijm nog iets van je collega's gehoord?

Als jullie nog even kunnen kijken naar dit PR graag. Het is niet per sé noodzakelijk om te reviewen omdat dit allemaal redactionele wijzigingen zijn. Donderdagmiddag ga ik deze mergen, versie ter vaststelling genereren en naar de stuurgroep sturen.