### PR TITLE
Use absolute URLs to refer to images

### DIFF
--- a/API-strategie-algemeen/Architectuur/architectuur.md
+++ b/API-strategie-algemeen/Architectuur/architectuur.md
@@ -136,7 +136,7 @@ Om als organisatie API's aan te bieden aan andere partijen op een gecontroleerde
 
 Het onderstaande API Capability model geeft weer aan welke onderwerpen men aandacht moet schenken bij het inrichten van API gedreven dienstverlening. De onderwerpen zijn gegroepeerd in de categorieën *Registratie & gebruik*, *Realisatie & beheer* en *Verkeersstroom beheer*.
 
-![API Capability Model](../../media/API-Capability.png)
+![API Capability Model](https://github.com/Geonovum/KP-APIs/raw/master/media/API-Capability.png)
 
 ### Registratie & Gebruik
 
@@ -402,7 +402,7 @@ In cloud-native implementaties zie je steeds vaker een meer gedistribueerd model
 In het API-Capability model zijn de functionaliteiten in detail beschreven.
 [API-Capability model](#api-capability-model)
 
-![](../../media/API-Management.jpg)
+![](https://github.com/Geonovum/KP-APIs/raw/master/media/API-Management.jpg)
 
 Figuur 5: Functionaliteit binnen API-Management
 


### PR DESCRIPTION
In the published version of the document, these images don't render using relative paths. Instead, we need to refer to the images via absolute URL pointing to GitHub.